### PR TITLE
Refactor: Remove _get_service_config_for_agent from Evaluator

### DIFF
--- a/src/base/state_manager.py
+++ b/src/base/state_manager.py
@@ -111,6 +111,18 @@ class BaseStateManager(ABC):
         self.tracked_resources.append(resource)
         logger.debug(f"Tracked {resource_type} resource: {identifier}")
     
+    def get_service_config_for_agent(self) -> dict:
+        """
+        Get service-specific configuration for agent execution.
+        
+        This method should be overridden by service implementations that need
+        to provide additional configuration to the agent.
+        
+        Returns:
+            Dictionary containing configuration needed by the agent/MCP server
+        """
+        return {}
+    
     def _cleanup_tracked_resources(self) -> bool:
         """Clean up all tracked resources."""
         cleanup_success = True

--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -1,7 +1,6 @@
 import time
 import json
 import shutil
-import os
 
 from datetime import datetime
 from pathlib import Path
@@ -12,8 +11,6 @@ from src.factory import MCPServiceFactory
 from src.model_config import ModelConfig
 from src.results_reporter import EvaluationReport, ResultsReporter, TaskResult
 from src.agent import MCPAgent
-from src.services import get_service_definition
-from src.config.config_schema import ConfigRegistry
 
 PIPELINE_RETRY_ERRORS: List[str] = [
     "State Duplication Error",
@@ -175,8 +172,8 @@ class MCPEvaluator:
         # Get task instruction from task manager
         task_instruction = self.task_manager.get_task_instruction(task)
         
-        # Prepare service-specific configuration for agent
-        service_config = self._get_service_config_for_agent(task)
+        # Get service-specific configuration from state manager
+        service_config = self.state_manager.get_service_config_for_agent()
         
         # Execute with agent
         agent_result = self.agent.execute_sync(task_instruction, **service_config)
@@ -191,50 +188,6 @@ class MCPEvaluator:
 
         return result
     
-    def _get_service_config_for_agent(self, task=None) -> dict:
-        """
-        Get service-specific configuration for agent execution.
-        
-        Args:
-            task: The task being executed (optional, needed for filesystem service)
-        
-        Returns:
-            Dictionary containing service-specific configuration
-        """
-        # Get service definition and eval config mapping
-        service_def = get_service_definition(self.service)
-        eval_config = service_def.get("eval_config", {})
-        
-        # Get actual configuration values from registry
-        config = ConfigRegistry.get_config(self.service).get_all()
-        
-        # Build service config based on eval_config mapping
-        service_config = {}
-        for agent_key, config_key in eval_config.items():
-            if config_key == "__from_state_manager__":
-                # Special handling for filesystem test directory
-                if agent_key == "test_directory":
-                    test_dir = None
-                    
-                    # First check if task has test_directory attribute (set by state manager)
-                    if task and hasattr(task, 'test_directory'):
-                        test_dir = task.test_directory
-                    # Fallback to state manager's current test directory
-                    elif hasattr(self.state_manager, 'get_test_directory'):
-                        test_dir_path = self.state_manager.get_test_directory()
-                        if test_dir_path:
-                            test_dir = str(test_dir_path)
-                    
-                    if test_dir:
-                        service_config[agent_key] = test_dir
-                        # Also set environment variable for verification scripts
-                        os.environ["FILESYSTEM_TEST_DIR"] = test_dir
-            else:
-                # Get value from config registry
-                if config_key in config:
-                    service_config[agent_key] = config[config_key]
-        
-        return service_config
 
     def run_evaluation(self, task_filter: str) -> EvaluationReport:
         """

--- a/src/mcp_services/filesystem/filesystem_state_manager.py
+++ b/src/mcp_services/filesystem/filesystem_state_manager.py
@@ -111,6 +111,9 @@ class FilesystemStateManager(BaseStateManager):
             if hasattr(task, '__dict__'):
                 task.test_directory = str(self.current_task_dir)
             
+            # Set environment variable for verification scripts and MCP server
+            os.environ["FILESYSTEM_TEST_DIR"] = str(self.current_task_dir)
+            
             # Create category-specific initial state
             self._setup_category_files(task.category)
             
@@ -228,6 +231,21 @@ class FilesystemStateManager(BaseStateManager):
             Path to the current test directory, or None if not set up
         """
         return self.current_task_dir
+    
+    def get_service_config_for_agent(self) -> dict:
+        """
+        Get service-specific configuration for agent execution.
+        
+        Returns:
+            Dictionary containing configuration needed by the agent/MCP server
+        """
+        service_config = {}
+        
+        # Add test directory if available
+        if self.current_task_dir:
+            service_config["test_directory"] = str(self.current_task_dir)
+        
+        return service_config
     
     def track_resource(self, resource_path: Path):
         """

--- a/src/mcp_services/github/github_state_manager.py
+++ b/src/mcp_services/github/github_state_manager.py
@@ -716,4 +716,19 @@ class GitHubStateManager(BaseStateManager):
         if response.status_code in [200, 201]:
             logger.debug(f"Created sample issue: {title}")
         else:
-            logger.warning(f"Failed to create sample issue: {response.status_code}") 
+            logger.warning(f"Failed to create sample issue: {response.status_code}")
+    
+    def get_service_config_for_agent(self) -> dict:
+        """
+        Get service-specific configuration for agent execution.
+        
+        Returns:
+            Dictionary containing configuration needed by the agent/MCP server
+        """
+        service_config = {}
+        
+        # Add GitHub token if available
+        if self.github_token:
+            service_config["github_token"] = self.github_token
+        
+        return service_config 

--- a/src/mcp_services/notion/notion_state_manager.py
+++ b/src/mcp_services/notion/notion_state_manager.py
@@ -476,3 +476,21 @@ class NotionStateManager(BaseStateManager):
         raise RuntimeError(
             f"Initial state duplication failed for task '{task_name}' after {max_retries + 1} attempts: {last_exc}"
         )
+    
+    def get_service_config_for_agent(self) -> dict:
+        """
+        Get service-specific configuration for agent execution.
+        
+        Returns:
+            Dictionary containing configuration needed by the agent/MCP server
+        """
+        from src.config.config_schema import ConfigRegistry
+        
+        # Get the eval_api_key from config registry
+        config = ConfigRegistry.get_config("notion").get_all()
+        service_config = {}
+        
+        if "eval_api_key" in config:
+            service_config["notion_key"] = config["eval_api_key"]
+        
+        return service_config


### PR DESCRIPTION
## Summary
Refactors the MCPEvaluator to remove tight coupling with service-specific configuration logic by moving `_get_service_config_for_agent` method functionality into individual state managers.

## Problem
The current implementation has several issues:
- **Tight coupling**: `_run_single_task` has implicit knowledge of filesystem service needs
- **Hidden side effects**: Environment variables are set as side effects in the evaluator
- **Fragile tests**: Services can break when evaluator is reused in different contexts  
- **Extensibility pain**: Adding new services requires modifying evaluator logic

## Solution
- ✅ **Deleted** `_get_service_config_for_agent` method from MCPEvaluator
- ✅ **Added** `get_service_config_for_agent()` method to BaseStateManager with default empty implementation
- ✅ **Implemented** service-specific configuration in each state manager:
  - `FilesystemStateManager`: Handles test directory setup and environment variables internally
  - `NotionStateManager`: Provides eval API key configuration from config registry
  - `GitHubStateManager`: Provides GitHub token configuration
- ✅ **Updated** `_run_single_task` to call `self.state_manager.get_service_config_for_agent()`
- ✅ **Removed** unused imports (`os`, `get_service_definition`, `ConfigRegistry`)

## Benefits
- **Cleaner separation of concerns** – Evaluator remains service-agnostic
- **Reduced bug surface** – No accidental parameter bleed into other services
- **Easier onboarding for new services** – Only implement necessary logic inside service package
- **Hidden side effects eliminated** – Environment variables set within appropriate service boundary

## Testing
- ✅ All state managers import correctly
- ✅ FilesystemStateManager properly sets up test directories and environment variables
- ✅ Service config methods return expected configuration dictionaries
- ✅ Evaluator no longer contains service-specific logic
- ✅ Backwards compatibility maintained - agents receive same configuration parameters

## Migration Guide
For new services, implement `get_service_config_for_agent()` in your state manager:
```python
def get_service_config_for_agent(self) -> dict:
    return {"service_key": self.service_value}
```

Closes #14