### PR TITLE
feat: migrate to slug-based task identifiers and drop legacy  support

### DIFF
--- a/src/base/task_manager.py
+++ b/src/base/task_manager.py
@@ -29,7 +29,7 @@ class BaseTask:
     task_verification_path: Path
     service: str
     category: str
-    task_id: int
+    task_id: str
     
     @property
     def name(self) -> str:
@@ -96,7 +96,8 @@ class BaseTaskManager(ABC):
                     logger.debug("Found task: %s", task.name)
         
         # Sort and cache
-        self._tasks_cache = sorted(tasks, key=lambda t: (t.category, t.task_id))
+        # Sort by category and a stringified task_id to handle both numeric IDs and slugs uniformly
+        self._tasks_cache = sorted(tasks, key=lambda t: (t.category, str(t.task_id)))
         logger.info("Discovered %d %s tasks across all categories", len(self._tasks_cache), self.service.title())
         return self._tasks_cache
     

--- a/src/results_reporter.py
+++ b/src/results_reporter.py
@@ -28,7 +28,7 @@ class TaskResult:
         success: Whether the task completed successfully.
         execution_time: Time taken to execute the task in seconds.
         category: The task category.
-        task_id: The task identifier number.
+        task_id: The task identifier (number or slug).
         error_message: Error message if the task failed.
         model_output: Agent conversation trajectory (messages).
     """
@@ -37,7 +37,7 @@ class TaskResult:
     success: bool
     execution_time: float  # in seconds
     category: Optional[str] = None
-    task_id: Optional[int] = None
+    task_id: Optional[str] = None
     error_message: Optional[str] = None
     model_output: Optional[Any] = None  # Agent conversation trajectory
     token_usage: Optional[Dict[str, int]] = None  # Token usage statistics


### PR DESCRIPTION
### What & Why

This PR deprecates the old task_<number> directory convention and standardises the codebase on the new Notion-style task layout.

From now on every task must live in a slug-named folder:
```bash
tasks/notion/<category>/<task_slug>/
    ├── description.md
    ├── verify.py
    └── meta.json