### PR TITLE
Migrate playwright form interaction to backend based

### DIFF
--- a/tasks/playwright/form_interaction/task_1/description.md
+++ b/tasks/playwright/form_interaction/task_1/description.md
@@ -5,13 +5,16 @@ Use Playwright MCP tools to interact with web forms and submit data.
 ## Requirements:
 
 1. Navigate to https://mcp-eval-website.vercel.app/forms/
-2. Fill out the customer information form with the following data:
-   - Customer Name: "John Doe" (text input, required)
-   - Phone Number: "123-456-7890" (text input, required)
-   - Email Address: "john.doe@example.com" (text input, required)
-   - Size: Select "Large" from dropdown (Small/Medium/Large, required)
-   - Delivery Time: Select "Afternoon" radio button (Morning/Afternoon/Evening, required)
-   - Additional Comments: "This is a test submission for MCPBench" (textarea, optional)
+2. Fill out the customer information form with the following data (add short pauses between fields):
+   - Customer Name: "John Doe"
+   - Phone Number: "123-456-7890" 
+   - Email Address: "john.doe@example.com"
+   - Size: Select "Large" from dropdown
+   - Delivery Time: Select "Afternoon" radio button  
+   - Additional Comments: "This is a test submission for MCPBench"
+   
+   After filling each field, wait 1-2 seconds and verify the field contains only the expected data. If any field contains data from multiple fields (concatenation), clear and re-fill that field before proceeding.
+
 3. Submit the form by clicking the submit button
 4. Wait for backend processing and redirect to /forms/result/{submission_id} page
 5. Capture the response page content and verify submitted data appears correctly
@@ -40,3 +43,5 @@ Use Playwright MCP tools to interact with web forms and submit data.
   - Comments: This is a test submission for MCPBench
   - Submitted At: {timestamp}
 - All submitted data matches the input values exactly
+
+Use Playwright MCP tools to complete this web automation task.

--- a/tasks/playwright/form_interaction/task_1/verify.py
+++ b/tasks/playwright/form_interaction/task_1/verify.py
@@ -2,14 +2,14 @@
 """
 Verification script for Playwright form interaction task.
 
-Verifies that the MCP agent successfully submitted the form and reached 
-the result page with correct data.
+Uses Playwright to navigate to the result page and verify the data directly.
 """
 
 import sys
 import json
 import re
 from pathlib import Path
+from playwright.sync_api import sync_playwright
 from typing import Dict, Any
 
 # Expected form data from task description
@@ -22,122 +22,116 @@ EXPECTED_DATA = {
     "comments": "This is a test submission for MCPBench"
 }
 
-def parse_mcp_results() -> Dict[str, Any]:
-    """Check if MCP agent reached result page and verify data."""
+def get_submission_id_from_messages() -> int:
+    """Extract submission ID from MCP agent messages."""
     messages_file = Path.cwd() / "messages.json"
     if not messages_file.exists():
-        return {"success": False, "error": "No messages.json found"}
+        raise FileNotFoundError("No messages.json found")
     
     try:
         with open(messages_file, 'r', encoding='utf-8') as f:
             messages = json.load(f)
     except Exception as e:
-        return {"success": False, "error": f"Failed to read messages.json: {e}"}
+        raise Exception(f"Failed to read messages.json: {e}")
     
-    # Look for evidence of reaching result page with correct URL pattern
-    result_url_found = False
-    submission_id = None
-    
+    # Look for result page URL in agent messages
     for message in messages:
         if message.get("type") == "function_call_output":
             output = str(message.get("output", ""))
-            
-            # Check for result page URL in browser outputs
             if "/forms/result/" in output:
                 match = re.search(r'/forms/result/(\d+)', output)
                 if match:
-                    result_url_found = True
-                    submission_id = int(match.group(1))
-                    break
+                    return int(match.group(1))
     
-    if not result_url_found:
-        return {"success": False, "error": "Agent did not reach result page"}
-    
-    # If we reached result page, try to validate the data shown
-    data_validation = validate_result_data_from_messages(messages)
-    
-    return {
-        "success": True,
-        "submission_id": submission_id,
-        "data_validation": data_validation
-    }
+    raise Exception("No result page URL found in agent messages")
 
-def validate_result_data_from_messages(messages) -> Dict[str, Any]:
-    """Extract and validate result page data from agent's messages."""
-    # Look for result page content in browser snapshots or outputs
-    result_content = ""
+def verify_result_page_with_playwright(submission_id: int) -> Dict[str, Any]:
+    """Navigate to result page with Playwright and verify the data."""
+    result_url = f"https://mcp-eval-website.vercel.app/forms/result/{submission_id}"
     
-    for message in messages:
-        if message.get("type") == "function_call_output":
-            output = str(message.get("output", ""))
-            if "submission" in output.lower() and ("john doe" in output.lower() or "customer name" in output.lower()):
-                result_content = output
-                break
-    
-    if not result_content:
-        return {"success": False, "error": "No result page data found in agent messages"}
-    
-    # Extract data using patterns
-    patterns = {
-        "customer_name": r"Customer Name:\s*(.+?)(?:\n|$)",
-        "phone_number": r"Phone Number:\s*(.+?)(?:\n|$)", 
-        "email_address": r"Email Address:\s*(.+?)(?:\n|$)",
-        "size": r"Size:\s*(.+?)(?:\n|$)",
-        "delivery_time": r"Delivery Time:\s*(.+?)(?:\n|$)",
-        "comments": r"Comments:\s*(.+?)(?:\n|$)"
-    }
-    
-    extracted_data = {}
-    for key, pattern in patterns.items():
-        match = re.search(pattern, result_content, re.IGNORECASE)
-        if match:
-            extracted_data[key] = match.group(1).strip()
-    
-    # Compare with expected data
-    data_matches = {}
-    for key, expected_value in EXPECTED_DATA.items():
-        actual_value = extracted_data.get(key, "").lower().strip()
-        expected_lower = expected_value.lower().strip()
-        data_matches[key] = actual_value == expected_lower
-    
-    return {
-        "success": True,
-        "extracted_data": extracted_data,
-        "data_matches": data_matches,
-        "all_correct": all(data_matches.values())
-    }
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page()
+            
+            print(f"📍 Navigating to result page: {result_url}")
+            page.goto(result_url, wait_until="networkidle")
+            
+            # Check if page loaded successfully
+            if "404" in page.title() or "not found" in page.content().lower():
+                browser.close()
+                return {"success": False, "error": f"Result page not found: {result_url}"}
+            
+            # Extract data from the page
+            page_content = page.inner_text("body")
+            print(f"📄 Page content loaded, checking data...")
+            
+            # Verify each field
+            data_matches = {}
+            extracted_data = {}
+            
+            # Check each expected field in the page content
+            content_lower = page_content.lower()
+            
+            for field, expected_value in EXPECTED_DATA.items():
+                expected_lower = expected_value.lower()
+                if expected_lower in content_lower:
+                    data_matches[field] = True
+                    extracted_data[field] = expected_value
+                    print(f"   ✅ {field}: '{expected_value}' found")
+                else:
+                    data_matches[field] = False
+                    extracted_data[field] = "NOT FOUND"
+                    print(f"   ❌ {field}: '{expected_value}' not found")
+            
+            browser.close()
+            
+            return {
+                "success": True,
+                "submission_id": submission_id,
+                "extracted_data": extracted_data,
+                "data_matches": data_matches,
+                "all_correct": all(data_matches.values()),
+                "page_content": page_content[:500] + "..." if len(page_content) > 500 else page_content
+            }
+            
+    except Exception as e:
+        return {"success": False, "error": f"Playwright verification failed: {str(e)}"}
 
 def verify_task() -> bool:
     """Main verification function."""
     print("🔍 Verifying Playwright Form Interaction Task")
     print("=" * 50)
     
-    # Parse MCP agent results
-    print("🤖 Checking MCP agent results...")
-    mcp_result = parse_mcp_results()
-    
-    if not mcp_result["success"]:
-        print(f"❌ {mcp_result.get('error')}")
-        return False
-    
-    print(f"✅ Agent reached result page with submission ID: {mcp_result['submission_id']}")
-    
-    # Check data validation
-    data_validation = mcp_result["data_validation"]
-    if not data_validation["success"]:
-        print(f"❌ Data validation failed: {data_validation.get('error')}")
-        return False
-    
-    if data_validation["all_correct"]:
-        print("✅ All submitted data appears correctly on result page")
-        return True
-    else:
-        print("❌ Some submitted data is incorrect:")
-        for field, matches in data_validation["data_matches"].items():
-            status = "✅" if matches else "❌"
-            expected = EXPECTED_DATA[field]
-            actual = data_validation["extracted_data"].get(field, "NOT FOUND")
-            print(f"   {status} {field}: expected '{expected}', got '{actual}'")
+    try:
+        # Step 1: Get submission ID from agent messages
+        print("📋 Extracting submission ID from agent messages...")
+        submission_id = get_submission_id_from_messages()
+        print(f"✅ Found submission ID: {submission_id}")
+        
+        # Step 2: Navigate to result page with Playwright and verify
+        print("🎭 Using Playwright to verify result page data...")
+        result = verify_result_page_with_playwright(submission_id)
+        
+        if not result["success"]:
+            print(f"❌ {result['error']}")
+            return False
+        
+        # Step 3: Check results
+        if result["all_correct"]:
+            print("✅ All submitted data appears correctly on result page")
+            return True
+        else:
+            print("❌ Some submitted data is incorrect:")
+            for field, matches in result["data_matches"].items():
+                status = "✅" if matches else "❌"
+                expected = EXPECTED_DATA[field]
+                actual = result["extracted_data"].get(field, "NOT FOUND")
+                print(f"   {status} {field}: expected '{expected}', got '{actual}'")
+            return False
+            
+    except Exception as e:
+        print(f"❌ Verification error: {e}")
         return False
 
 def main():


### PR DESCRIPTION
- Remove independent form testing functionality
- Focus verification purely on checking if MCP agent reached /forms/result/{id} page
- Validate data extraction from agent's result page interactions
