### PR TITLE
fix: add test_environments volume mount for non-postgres services

### DIFF
--- a/run-task.sh
+++ b/run-task.sh
@@ -132,6 +132,7 @@ else
         --memory="$DOCKER_MEMORY_LIMIT" \
         --cpus="$DOCKER_CPU_LIMIT" \
         -v "$(pwd)/results:/app/results" \
+        -v "$(pwd)/test_environments:/app/test_environments" \
         $([ -f .mcp_env ] && echo "-v $(pwd)/.mcp_env:/app/.mcp_env:ro") \
         $([ -f notion_state.json ] && echo "-v $(pwd)/notion_state.json:/app/notion_state.json:ro") \
         "$DOCKER_IMAGE" \


### PR DESCRIPTION
Ensures consistency with postgres service configuration by mounting the test_environments directory for all services, not just postgres.