### PR TITLE
fix: align default service to filesystem across Python and Docker

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -32,9 +32,9 @@ def main():
     # Main configuration
     parser.add_argument(
         "--mcp",
-        default="notion",
+        default="filesystem",
         choices=supported_mcp_services,
-        help="MCP service to use (default: notion)",
+        help="MCP service to use (default: filesystem)",
     )
     parser.add_argument(
         "--models",


### PR DESCRIPTION
Change default service in pipeline.py from 'notion' to 'filesystem' to match run-task.sh default