### PR TITLE
refactor: rename MCP Arena to MCPMark across codebase

### DIFF
--- a/DOCKER_USAGE.md
+++ b/DOCKER_USAGE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The MCP Arena Docker setup provides a simple way to run evaluation tasks in isolated containers. PostgreSQL is automatically handled when needed.
+The MCPMark Docker setup provides a simple way to run evaluation tasks in isolated containers. PostgreSQL is automatically handled when needed.
 
 ## Quick Start
 
@@ -83,7 +83,7 @@ docker run --rm \
   -v $(pwd)/results:/app/results \
   -v $(pwd)/.mcp_env:/app/.mcp_env:ro \
   -v $(pwd)/notion_state.json:/app/notion_state.json:ro \
-  mcp-arena:latest \
+  evalsysorg/mcpmark:latest \
   python3 -m pipeline --mcp notion --models o3 --exp-name test --tasks all
 ```
 
@@ -106,7 +106,7 @@ docker run --rm \
   -e POSTGRES_HOST=mcp-postgres \
   -v $(pwd)/results:/app/results \
   -v $(pwd)/.mcp_env:/app/.mcp_env:ro \
-  mcp-arena:latest \
+  evalsysorg/mcpmark:latest \
   python3 -m pipeline --mcp postgres --models o3 --exp-name pg-test --tasks all
 
 # Stop and remove postgres when done

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Build Docker image for MCP Arena
+# Build Docker image for MCPMark
 set -e
 
 # Color codes for output

--- a/run-benchmark.sh
+++ b/run-benchmark.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# MCP Arena Full Benchmark Runner
+# MCPMark Full Benchmark Runner
 # Runs all tasks across all MCP services for comprehensive model evaluation
 
 set -e
@@ -163,7 +163,7 @@ IFS=',' read -ra SERVICE_ARRAY <<< "$SERVICES"
 
 # Summary
 echo ""
-print_status "MCP Arena Benchmark Configuration"
+print_status "MCPMark Benchmark Configuration"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Models:      $MODELS"
 echo "Experiment:  $EXP_NAME"

--- a/run-task.sh
+++ b/run-task.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# MCP Arena Task Runner
+# MCPMark Task Runner
 # Enable strict error handling
 set -euo pipefail
 
@@ -35,11 +35,11 @@ while [[ $# -gt 0 ]]; do
             cat << EOF
 Usage: $0 [--mcp SERVICE] [PIPELINE_ARGS]
 
-Run MCP Arena tasks in Docker containers.
+Run MCPMark tasks in Docker containers.
 
 Options:
     --mcp SERVICE    MCP service (notion|github|filesystem|playwright|postgres)
-                        Default: notion
+                        Default: filesystem
 
 Environment Variables:
     DOCKER_MEMORY_LIMIT  Memory limit for container (default: 4g)


### PR DESCRIPTION
Update all references from 'MCP Arena' to 'MCPMark' for brand consistency