### PR TITLE
The expected URL could also have a tailing slash for github task missing-semester/find_legacy_name

### DIFF
--- a/tasks/github/missing-semester/find_legacy_name/verify.py
+++ b/tasks/github/missing-semester/find_legacy_name/verify.py
@@ -55,6 +55,7 @@ def verify() -> bool:
     """
     # Expected answer content
     EXPECTED_CONTENT = "[Hacker Tools](https://hacker-tools.github.io)"
+    EXPECTED_CONTENT_2 = "[Hacker Tools](https://hacker-tools.github.io/)"
     
     # Load environment variables from .mcp_env
     load_dotenv(".mcp_env")
@@ -93,9 +94,9 @@ def verify() -> bool:
     print("2. Verifying ANSWER.md content...")
     answer_content = answer_content.strip()
     
-    if answer_content != EXPECTED_CONTENT:
+    if answer_content != EXPECTED_CONTENT and answer_content != EXPECTED_CONTENT_2:
         print(f"Error: ANSWER.md content does not match expected answer", file=sys.stderr)
-        print(f"Expected: {EXPECTED_CONTENT}", file=sys.stderr)
+        print(f"Expected: {EXPECTED_CONTENT} or {EXPECTED_CONTENT_2}", file=sys.stderr)
         print(f"Found: {answer_content}", file=sys.stderr)
         return False
 
@@ -104,7 +105,7 @@ def verify() -> bool:
     print("\n✅ All verification checks passed!")
     print("Legacy name finding task completed successfully:")
     print(f"  - ANSWER.md created in master branch")
-    print(f"  - Content: {EXPECTED_CONTENT}")
+    print(f"  - Content: {answer_content}")
 
     return True
 

--- a/tasks/github/missing-semester/find_legacy_name/verify.py
+++ b/tasks/github/missing-semester/find_legacy_name/verify.py
@@ -53,9 +53,11 @@ def verify() -> bool:
     Programmatically verify that the legacy name finding task was completed correctly.
     Checks for ANSWER.md file in master branch with the correct content.
     """
-    # Expected answer content
-    EXPECTED_CONTENT = "[Hacker Tools](https://hacker-tools.github.io)"
-    EXPECTED_CONTENT_2 = "[Hacker Tools](https://hacker-tools.github.io/)"
+    # Expected answer content (accept both with and without trailing slash)
+    EXPECTED_CONTENTS = {
+        "[Hacker Tools](https://hacker-tools.github.io)",
+        "[Hacker Tools](https://hacker-tools.github.io/)",
+    }
     
     # Load environment variables from .mcp_env
     load_dotenv(".mcp_env")
@@ -94,9 +96,9 @@ def verify() -> bool:
     print("2. Verifying ANSWER.md content...")
     answer_content = answer_content.strip()
     
-    if answer_content != EXPECTED_CONTENT and answer_content != EXPECTED_CONTENT_2:
-        print(f"Error: ANSWER.md content does not match expected answer", file=sys.stderr)
-        print(f"Expected: {EXPECTED_CONTENT} or {EXPECTED_CONTENT_2}", file=sys.stderr)
+    if answer_content not in EXPECTED_CONTENTS:
+        print(f"Error: ANSWER.md content does not match expected answer(s)", file=sys.stderr)
+        print(f"Expected one of: {sorted(EXPECTED_CONTENTS)}", file=sys.stderr)
         print(f"Found: {answer_content}", file=sys.stderr)
         return False
 
@@ -105,7 +107,7 @@ def verify() -> bool:
     print("\n✅ All verification checks passed!")
     print("Legacy name finding task completed successfully:")
     print(f"  - ANSWER.md created in master branch")
-    print(f"  - Content: {answer_content}")
+    print(f"  - Content accepted: {answer_content}")
 
     return True
 


### PR DESCRIPTION
The template containing the second URL.
<img width="2212" height="356" alt="image" src="https://github.com/user-attachments/assets/a36774b1-1cb4-490f-b492-298852013a09" />
 I didn't see any URL format requirement in the task description, so it should also be considered as a correct answer.