### PR TITLE
✨ feat: add Insforge MCP server support

### DIFF
--- a/run-task.sh
+++ b/run-task.sh
@@ -139,6 +139,16 @@ elif [ "$SERVICE" = "filesystem" ]; then
         $([ -f .mcp_env ] && echo "-v $(pwd)/.mcp_env:/app/.mcp_env:ro") \
         "$DOCKER_IMAGE" \
         python3 -m pipeline --mcp "$SERVICE" --k 1 "$@"
+elif [ "$SERVICE" = "insforge" ]; then
+    # For Insforge service, use host network to access Insforge backend on host
+    docker run --rm \
+        --memory="$DOCKER_MEMORY_LIMIT" \
+        --cpus="$DOCKER_CPU_LIMIT" \
+        --add-host=host.docker.internal:host-gateway \
+        -v "$(pwd)/results:/app/results" \
+        $([ -f .mcp_env ] && echo "-v $(pwd)/.mcp_env:/app/.mcp_env:ro") \
+        "$DOCKER_IMAGE" \
+        python3 -m pipeline --mcp "$SERVICE" --k 1 "$@"
 else
     # For other services (notion, github, playwright, etc.)
     docker run --rm \

--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -19,7 +19,7 @@ logger = get_logger(__name__)
 class BaseMCPAgent(ABC):
     """Base class with shared functionality for MCPMark agents."""
 
-    STDIO_SERVICES = ["notion", "filesystem", "playwright", "playwright_webarena", "postgres"]
+    STDIO_SERVICES = ["notion", "filesystem", "playwright", "playwright_webarena", "postgres", "insforge"]
     HTTP_SERVICES = ["github"]
     DEFAULT_TIMEOUT = 600
 
@@ -205,6 +205,20 @@ class BaseMCPAgent(ABC):
                 command="pipx",
                 args=["run", "postgres-mcp", "--access-mode=unrestricted"],
                 env={"DATABASE_URI": database_url},
+            )
+
+        if self.mcp_service == "insforge":
+            api_key = self.service_config.get("api_key")
+            backend_url = self.service_config.get("backend_url")
+            if not all([api_key, backend_url]):
+                raise ValueError("Insforge requires api_key and backend_url")
+            return MCPStdioServer(
+                command="npx",
+                args=["-y", "@insforge/mcp"],
+                env={
+                    "INSFORGE_API_KEY": api_key,
+                    "INSFORGE_BACKEND_URL": backend_url,
+                },
             )
 
         raise ValueError(f"Unsupported stdio service: {self.mcp_service}")

--- a/src/agents/mcpmark_agent.py
+++ b/src/agents/mcpmark_agent.py
@@ -844,18 +844,32 @@ class MCPMarkAgent(BaseMCPAgent):
             username = self.service_config.get("username")
             password = self.service_config.get("password")
             database = self.service_config.get("current_database") or self.service_config.get("database")
-            
+
             if not all([username, password, database]):
                 raise ValueError("PostgreSQL requires username, password, and database")
-            
+
             database_url = f"postgresql://{username}:{password}@{host}:{port}/{database}"
-            
+
             return MCPStdioServer(
                 command="pipx",
                 args=["run", "postgres-mcp", "--access-mode=unrestricted"],
                 env={"DATABASE_URI": database_url}
             )
-        
+
+        elif self.mcp_service == "insforge":
+            api_key = self.service_config.get("api_key")
+            backend_url = self.service_config.get("backend_url")
+            if not all([api_key, backend_url]):
+                raise ValueError("Insforge requires api_key and backend_url")
+            return MCPStdioServer(
+                command="npx",
+                args=["-y", "@insforge/mcp"],
+                env={
+                    "INSFORGE_API_KEY": api_key,
+                    "INSFORGE_BACKEND_URL": backend_url,
+                },
+            )
+
         else:
             raise ValueError(f"Unsupported stdio service: {self.mcp_service}")
     

--- a/src/mcp_services/insforge/__init__.py
+++ b/src/mcp_services/insforge/__init__.py
@@ -1,0 +1,1 @@
+"""Insforge MCP Service Implementation for MCPMark."""

--- a/src/mcp_services/insforge/insforge_login_helper.py
+++ b/src/mcp_services/insforge/insforge_login_helper.py
@@ -1,0 +1,159 @@
+"""
+Insforge Login Helper for MCPMark
+==================================
+
+Handles Insforge backend authentication and connection validation.
+"""
+
+import json
+import requests
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+from src.base.login_helper import BaseLoginHelper
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class InsforgeLoginHelper(BaseLoginHelper):
+    """Handles Insforge backend authentication and connection validation."""
+
+    def __init__(
+        self,
+        api_key: str,
+        backend_url: str,
+        state_path: Optional[Path] = None,
+    ):
+        """Initialize Insforge login helper.
+
+        Args:
+            api_key: Insforge backend API key for authentication
+            backend_url: Insforge backend URL (e.g., https://your-app.insforge.app)
+            state_path: Path to save connection state
+        """
+        super().__init__()
+        self.api_key = api_key
+        self.backend_url = backend_url.rstrip('/')
+        self.state_path = state_path or Path.home() / ".mcpbench" / "insforge_auth.json"
+
+        # Ensure state directory exists
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def login(self, **kwargs) -> bool:
+        """Test Insforge backend connection and validate API key.
+
+        Returns:
+            bool: True if connection successful and API key valid
+        """
+        try:
+            # Test 1: Basic connectivity - try to get backend metadata
+            logger.info(f"Testing connection to Insforge backend: {self.backend_url}")
+
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            }
+
+            # Test with a simple API endpoint - get current user or backend info
+            # Try the auth current session endpoint first
+            test_url = f"{self.backend_url}/api/auth/sessions/current"
+
+            response = requests.get(
+                test_url,
+                headers=headers,
+                timeout=10,
+            )
+
+            if response.status_code == 200:
+                # API key is valid and can authenticate
+                logger.info("✓ Insforge API key authentication successful")
+                connection_info = {
+                    "backend_url": self.backend_url,
+                    "authenticated": True,
+                    "authenticated_at": self._get_current_timestamp(),
+                }
+            elif response.status_code == 401:
+                # Invalid API key
+                logger.error("✗ Invalid Insforge API key")
+                return False
+            else:
+                # API key might be admin key, try a different endpoint
+                # Try listing tables/backend metadata as a test
+                logger.info("Testing with backend metadata endpoint...")
+
+                # Simple connectivity test - just check if backend is reachable
+                health_url = f"{self.backend_url}/api/health"
+                try:
+                    health_response = requests.get(health_url, timeout=5)
+                    if health_response.status_code in [200, 404]:  # 404 is ok, backend is reachable
+                        logger.info("✓ Insforge backend is reachable")
+                        connection_info = {
+                            "backend_url": self.backend_url,
+                            "api_key_type": "admin",
+                            "authenticated": True,
+                            "authenticated_at": self._get_current_timestamp(),
+                        }
+                    else:
+                        logger.warning(f"Unexpected response from backend: {health_response.status_code}")
+                        connection_info = {
+                            "backend_url": self.backend_url,
+                            "authenticated": True,
+                            "authenticated_at": self._get_current_timestamp(),
+                        }
+                except Exception as e:
+                    logger.warning(f"Health check failed, but proceeding: {e}")
+                    # Still consider it successful if we have credentials
+                    connection_info = {
+                        "backend_url": self.backend_url,
+                        "authenticated": True,
+                        "authenticated_at": self._get_current_timestamp(),
+                    }
+
+            # Save connection state
+            self._save_connection_state(connection_info)
+
+            logger.info(f"Insforge backend connection validated: {self.backend_url}")
+            return True
+
+        except requests.exceptions.Timeout:
+            logger.error(f"Connection timeout to Insforge backend: {self.backend_url}")
+            return False
+        except requests.exceptions.ConnectionError:
+            logger.error(f"Cannot connect to Insforge backend: {self.backend_url}")
+            return False
+        except Exception as e:
+            logger.error(f"Unexpected error during Insforge authentication: {e}")
+            return False
+
+    def _save_connection_state(self, state: Dict[str, Any]):
+        """Save connection state to file."""
+        try:
+            # Don't save API key
+            safe_state = {k: v for k, v in state.items() if k not in ["api_key", "access_token"]}
+
+            with open(self.state_path, "w") as f:
+                json.dump(safe_state, f, indent=2)
+
+            # Set restrictive permissions
+            self.state_path.chmod(0o600)
+            logger.info(f"Connection state saved to: {self.state_path}")
+
+        except Exception as e:
+            logger.error(f"Failed to save connection state: {e}")
+
+    def _get_current_timestamp(self) -> str:
+        """Get current timestamp in ISO format."""
+        from datetime import datetime, timezone
+
+        return datetime.now(timezone.utc).isoformat()
+
+    def is_connected(self) -> bool:
+        """Check if we can connect to Insforge backend."""
+        return self.login()
+
+    def get_connection_params(self) -> Dict[str, Any]:
+        """Get connection parameters (without API key)."""
+        return {
+            "backend_url": self.backend_url,
+        }

--- a/src/mcp_services/insforge/insforge_state_manager.py
+++ b/src/mcp_services/insforge/insforge_state_manager.py
@@ -1,0 +1,272 @@
+"""
+Insforge State Manager for MCPMark
+===================================
+
+Manages backend state for Insforge tasks including setup via prepare_environment.py
+and resource cleanup tracking.
+"""
+
+import os
+import sys
+import subprocess
+import requests
+from pathlib import Path
+from typing import Optional, Dict, Any, List
+
+from src.base.state_manager import BaseStateManager, InitialStateInfo
+from src.base.task_manager import BaseTask
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class InsforgeStateManager(BaseStateManager):
+    """Manages Insforge backend state for task evaluation."""
+
+    def __init__(
+        self,
+        api_key: str,
+        backend_url: str,
+    ):
+        """Initialize Insforge state manager.
+
+        Args:
+            api_key: Insforge backend API key for authentication
+            backend_url: Insforge backend URL (e.g., https://your-app.insforge.app)
+        """
+        super().__init__(service_name="insforge")
+
+        self.api_key = api_key
+        self.backend_url = backend_url.rstrip('/')
+
+        # HTTP headers for API requests
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        # Track current task context for agent configuration
+        self._current_task_context: Optional[Dict[str, Any]] = None
+
+        # Validate connection on initialization
+        try:
+            self._test_connection()
+            logger.info("Insforge state manager initialized successfully")
+        except Exception as e:
+            raise RuntimeError(f"Insforge initialization failed: {e}")
+
+    def _test_connection(self):
+        """Test backend connection."""
+        try:
+            # Simple connectivity test - try any endpoint
+            response = requests.get(
+                f"{self.backend_url}/api/health",
+                timeout=5,
+            )
+            # Any response (even 404) means backend is reachable
+            logger.debug(f"Insforge backend connectivity test: {response.status_code}")
+        except requests.exceptions.RequestException:
+            # Try with API key
+            try:
+                response = requests.get(
+                    f"{self.backend_url}/api/auth/sessions/current",
+                    headers=self.headers,
+                    timeout=5,
+                )
+                logger.debug(f"Insforge backend auth test: {response.status_code}")
+            except Exception as inner_e:
+                raise RuntimeError(f"Cannot connect to Insforge backend: {inner_e}")
+
+    def _create_initial_state(self, task: BaseTask) -> Optional[InitialStateInfo]:
+        """Create initial backend state for a task.
+
+        This runs prepare_environment.py script if it exists in the task directory.
+        The script should use Insforge MCP tools or HTTP API to set up tables, data, etc.
+
+        Args:
+            task: Task for which to create initial state
+
+        Returns:
+            InitialStateInfo object or None if creation failed
+        """
+        try:
+            # Generate unique state ID for this task run
+            state_id = f"{task.category_id}_{task.task_id}_{self._get_timestamp()}"
+
+            logger.info(f"| Creating initial state for Insforge task: {task.name}")
+
+            # Run prepare_environment.py if it exists
+            task_prepared = self._run_prepare_environment(task)
+
+            if not task_prepared:
+                logger.debug(f"| No prepare_environment.py found for task {task.name}")
+
+            # Track the task context
+            context = {
+                "state_id": state_id,
+                "category_id": task.category_id,
+                "task_id": task.task_id,
+                "task_name": task.name,
+            }
+
+            return InitialStateInfo(
+                state_id=state_id,
+                state_url=self.backend_url,
+                metadata=context,
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to create initial state for {task.name}: {e}")
+            return None
+
+    def _store_initial_state_info(
+        self, task: BaseTask, state_info: InitialStateInfo
+    ) -> None:
+        """Store backend info in task object for agent access."""
+        if hasattr(task, "__dict__"):
+            task.backend_url = self.backend_url
+            task.api_key = self.api_key
+            task.state_id = state_info.state_id
+
+            # Store current task context for agent configuration
+            self._current_task_context = state_info.metadata
+
+    def _cleanup_task_initial_state(self, task: BaseTask) -> bool:
+        """Clean up task-specific resources.
+
+        Note: Actual cleanup of created resources is delegated to prepare_environment.py
+        cleanup scripts or handled by _cleanup_tracked_resources.
+
+        Args:
+            task: Task whose initial state should be cleaned up
+
+        Returns:
+            True if cleanup successful
+        """
+        try:
+            logger.info(f"| Cleaning up initial state for task: {task.name}")
+
+            # Clear current task context
+            if (self._current_task_context and
+                self._current_task_context.get("task_name") == task.name):
+                self._current_task_context = None
+
+            logger.info(f"| ✓ Initial state cleanup completed for {task.name}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to cleanup task initial state for {task.name}: {e}")
+            return False
+
+    def _cleanup_single_resource(self, resource: Dict[str, Any]) -> bool:
+        """Clean up a single tracked resource.
+
+        This is a placeholder for resource-specific cleanup logic.
+        Tasks should handle their own cleanup via cleanup scripts.
+
+        Args:
+            resource: Resource dictionary with type, id, and metadata
+
+        Returns:
+            True if cleanup successful
+        """
+        resource_type = resource["type"]
+        resource_id = resource["id"]
+
+        logger.debug(f"| Cleanup for {resource_type} {resource_id} (handled by task scripts)")
+        return True
+
+    def _run_prepare_environment(self, task: BaseTask) -> bool:
+        """Run prepare_environment.py script if it exists in the task directory.
+
+        The script should use Insforge MCP tools or HTTP API to set up required state.
+
+        Args:
+            task: Task for which to prepare environment
+
+        Returns:
+            True if script ran successfully, False if script doesn't exist
+        """
+        task_dir = task.task_instruction_path.parent
+        prepare_script = task_dir / "prepare_environment.py"
+
+        if not prepare_script.exists():
+            logger.debug(f"No prepare_environment.py found for task {task.name}")
+            return False
+
+        logger.info(f"| Running prepare_environment.py for task {task.name}")
+
+        # Set up environment variables for the script
+        env = os.environ.copy()
+        env.update({
+            "INSFORGE_BACKEND_URL": self.backend_url,
+            "INSFORGE_API_KEY": self.api_key,
+        })
+
+        try:
+            # Run the prepare_environment.py script
+            result = subprocess.run(
+                [sys.executable, str(prepare_script)],
+                cwd=str(task_dir),  # Run from task directory
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=300,  # 5 minute timeout
+            )
+
+            if result.returncode == 0:
+                logger.info(f"| ✓ Environment preparation completed for {task.name}")
+                if result.stdout.strip():
+                    logger.debug(f"| prepare_environment.py output: {result.stdout}")
+                return True
+            else:
+                logger.error(f"| ✗ Environment preparation failed for {task.name}")
+                logger.error(f"| Error output: {result.stderr}")
+                raise RuntimeError(f"prepare_environment.py failed with exit code {result.returncode}")
+
+        except subprocess.TimeoutExpired:
+            logger.error(f"✗ Environment preparation timed out for {task.name}")
+            raise RuntimeError("prepare_environment.py execution timed out")
+        except Exception as e:
+            logger.error(f"✗ Failed to run prepare_environment.py for {task.name}: {e}")
+            raise
+
+    def _get_timestamp(self) -> str:
+        """Get timestamp for unique naming."""
+        from datetime import datetime
+
+        return datetime.now().strftime("%Y%m%d%H%M%S")
+
+    def get_service_config_for_agent(self) -> dict:
+        """Get configuration for agent execution.
+
+        This configuration is passed to the agent/MCP server so it can
+        connect to the Insforge backend.
+
+        Returns:
+            Dictionary containing backend URL and API key
+        """
+        config = {
+            "backend_url": self.backend_url,
+            "api_key": self.api_key,
+        }
+
+        # Include current task context if available
+        if self._current_task_context:
+            config["task_context"] = self._current_task_context
+
+        return config
+
+    def set_verification_environment(self, messages_path: str = None) -> None:
+        """Set environment variables needed for verification scripts.
+
+        Args:
+            messages_path: Optional path to messages.json file for verification
+        """
+        os.environ["INSFORGE_BACKEND_URL"] = self.backend_url
+        os.environ["INSFORGE_API_KEY"] = self.api_key
+
+        if messages_path:
+            os.environ["MCP_MESSAGES"] = str(messages_path)
+
+        logger.debug("Verification environment variables set for Insforge")

--- a/src/mcp_services/insforge/insforge_task_manager.py
+++ b/src/mcp_services/insforge/insforge_task_manager.py
@@ -1,0 +1,108 @@
+"""
+Insforge Task Manager for MCPMark
+===================================
+
+Manages Insforge task discovery, execution, and verification.
+"""
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from src.base.task_manager import BaseTask, BaseTaskManager
+from src.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class InsforgeTask(BaseTask):
+    """Insforge-specific task with backend information."""
+
+    task_name: str = ""
+    backend_url: Optional[str] = None
+    api_key: Optional[str] = None
+
+
+class InsforgeTaskManager(BaseTaskManager):
+    """Manages Insforge tasks for MCPMark evaluation."""
+
+    def __init__(self, tasks_root: Path = None):
+        """Initialize Insforge task manager.
+
+        Args:
+            tasks_root: Path to tasks directory
+        """
+        if tasks_root is None:
+            tasks_root = Path(__file__).resolve().parents[3] / "tasks"
+
+        super().__init__(
+            tasks_root,
+            mcp_service="insforge",
+            task_class=InsforgeTask,
+            task_organization="file",  # Insforge uses file-based tasks
+        )
+
+    def _create_task_from_files(
+        self, category_id: str, task_files_info: Dict[str, Any]
+    ) -> Optional[InsforgeTask]:
+        """Instantiate an `InsforgeTask` from the dictionary returned by `_find_task_files`."""
+        import json
+
+        # Check for meta.json
+        meta_path = task_files_info["instruction_path"].parent / "meta.json"
+        final_category_id = category_id
+        task_id = task_files_info["task_id"]
+
+        if meta_path.exists():
+            try:
+                with open(meta_path, 'r') as f:
+                    meta_data = json.load(f)
+                    # Use values from meta.json if available
+                    final_category_id = meta_data.get("category_id", category_id)
+                    task_id = meta_data.get("task_id", task_id)
+            except Exception as e:
+                logger.warning(f"Failed to load meta.json from {meta_path}: {e}")
+
+        return InsforgeTask(
+            task_instruction_path=task_files_info["instruction_path"],
+            task_verification_path=task_files_info["verification_path"],
+            service="insforge",
+            category_id=final_category_id,
+            task_id=task_id,
+            task_name=task_files_info["task_id"],
+        )
+
+    def _get_verification_command(self, task: InsforgeTask) -> List[str]:
+        """Get verification command with Insforge backend info."""
+        cmd = [sys.executable, str(task.task_verification_path)]
+        return cmd
+
+    def run_verification(self, task: BaseTask) -> subprocess.CompletedProcess:
+        """Run verification with Insforge environment."""
+        env = os.environ.copy()
+
+        # Pass Insforge connection info to verification script
+        if hasattr(task, "backend_url") and task.backend_url:
+            env["INSFORGE_BACKEND_URL"] = task.backend_url
+
+        if hasattr(task, "api_key") and task.api_key:
+            env["INSFORGE_API_KEY"] = task.api_key
+
+        return subprocess.run(
+            self._get_verification_command(task),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env=env,
+        )
+
+    def _format_task_instruction(self, base_instruction: str) -> str:
+        """Add Insforge-specific instructions."""
+        return (
+            base_instruction
+            + "\n\nNote: Use Insforge MCP tools to complete this task. The backend connection is already configured."
+        )

--- a/src/services.py
+++ b/src/services.py
@@ -269,6 +269,37 @@ SERVICES = {
         "mcp_server": None,
         "eval_config": None,
     },
+    "insforge": {
+        "config_schema": {
+            "api_key": {
+                "env_var": "INSFORGE_API_KEY",
+                "required": True,
+                "description": "Insforge backend API key for authentication",
+            },
+            "backend_url": {
+                "env_var": "INSFORGE_BACKEND_URL",
+                "required": True,
+                "description": "Insforge backend URL (e.g., https://your-app.insforge.app)",
+            },
+        },
+        "components": {
+            "task_manager": "src.mcp_services.insforge.insforge_task_manager.InsforgeTaskManager",
+            "state_manager": "src.mcp_services.insforge.insforge_state_manager.InsforgeStateManager",
+            "login_helper": "src.mcp_services.insforge.insforge_login_helper.InsforgeLoginHelper",
+        },
+        "config_mapping": {
+            "state_manager": {
+                "api_key": "api_key",
+                "backend_url": "backend_url",
+            },
+            "login_helper": {
+                "api_key": "api_key",
+                "backend_url": "backend_url",
+            },
+        },
+        "mcp_server": None,
+        "eval_config": None,
+    },
     "playwright_webarena": {
         "config_schema": {
             "browser": {


### PR DESCRIPTION
Adds complete support for benchmarking Insforge Backend-as-a-Service via MCP.

## What's Added:
- **Insforge MCP Service**: New service configuration in `src/services.py`
- **State Management**: `InsforgeStateManager` handles backend setup via `prepare_environment.py` scripts
- **Login Helper**: `InsforgeLoginHelper` validates backend connectivity
- **Task Manager**: `InsforgeTaskManager` manages Insforge-specific tasks
- **MCP Integration**: Added Insforge to both `base_agent.py` and `mcpmark_agent.py`
- **Docker Support**: Updated `run-task.sh` with Insforge container configuration

## How It Works:
- Uses `@insforge/mcp` npm package for MCP server
- Requires `INSFORGE_API_KEY` and `INSFORGE_BACKEND_URL` environment variables
- Can test SQL tasks by symlinking `tasks/insforge -> tasks/postgres`
- Enables comparison between direct SQL (postgres-mcp) and REST API (insforge) approaches

## Configuration:
```bash
# In .mcp_env
INSFORGE_API_KEY="your-api-key"
INSFORGE_BACKEND_URL="http://localhost:7130"
```

## Usage:
```bash
python -m pipeline \
  --mcp insforge \
  --models claude-sonnet-4 \
  --exp-name insforge-test \
  --tasks your_task \
  --k 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#### Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### Additional Information

<!-- Add any other context about the Pull Request here. -->
