### PR TITLE
fix: pin MCP server versions for reproducible benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ MCPMark provides a reproducible, extensible benchmark for researchers and engine
 
 ## News
 
+- 📌 **21 Jan** — Pinned MCP server versions for reproducible benchmarks: GitHub MCP Server `v0.15.0` (switched to Docker for version control), Notion MCP Server `@1.9.1` (Notion released 2.0 but it has many bugs, not recommended). See [#246](https://github.com/eval-sys/mcpmark/pull/246).
 - 🔥 **13 Dec** — Added auto-compaction support (`--compaction-token`) to summarize long conversations and avoid context overflow during evaluation ([#236](https://github.com/eval-sys/mcpmark/pull/236])).
 - 🏅 **02 Dec** — Evaluated `gemini-3-pro-preview` (thinking: low): **Pass@1 50.6%** ± 2.3% — so close to `gpt-5-high` (51.6%)! Also `deepseek-v3.2-thinking` 36.8% and `deepseek-v3.2-chat` 29.7%
 - 🔥 **02 Dec** — Obfuscate GitHub @mentions to prevent notification spam during evaluation ([#229](https://github.com/eval-sys/mcpmark/pull/229))

--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -26,8 +26,9 @@ class BaseMCPAgent(ABC):
         "playwright_webarena",
         "postgres",
         "insforge",
+        "github",
     ]
-    HTTP_SERVICES = ["github", "supabase"]
+    HTTP_SERVICES = ["supabase"]
     DEFAULT_TIMEOUT = 600
     COMPACTION_DISABLED_TOKEN = 999_999_999
 


### PR DESCRIPTION
## Summary

MCP servers are constantly evolving, and version changes can affect benchmark results. To ensure reproducibility, we pin to specific versions:

- **GitHub MCP Server**: `v0.15.0` (93 tools)
  - Switched from HTTP remote API to Docker-based STDIO for version control
  - Remote API at `api.githubcopilot.com` doesn't support version pinning

- **Notion MCP Server**: `@notionhq/notion-mcp-server@1.9.1`
  - Already pinned, no change needed

### NotionStateManager Improvements

Also includes improvements to NotionStateManager:
- Add source hub orphan cleanup to prevent duplicate page accumulation  

## Test plan

- [x] Run GitHub benchmark tasks with pinned version
- [x] Run Notion benchmark tasks to verify state manager improvements
- [x] Verify Docker-based GitHub MCP server starts correctly


close https://github.com/eval-sys/mcpmark/issues/245