### PR TITLE
Tighten standard playwright_webarena verify scripts + smart-quote normalization

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -113,7 +113,7 @@ def main():
     parser.add_argument(
         "--reasoning-effort",
         default="default",
-        choices=["default", "minimal", "low", "medium", "high"],
+        choices=["default", "minimal", "low", "medium", "high", "xhigh"],
         help="Reasoning effort level for supported models (default: None)",
     )
 

--- a/src/model_config.py
+++ b/src/model_config.py
@@ -50,6 +50,11 @@ class ModelConfig:
             "api_key_var": "OPENAI_API_KEY",
             "litellm_input_model_name": "openai/gpt-5.2",
         },
+        "gpt-5.5": {
+            "provider": "openai",
+            "api_key_var": "OPENAI_API_KEY",
+            "litellm_input_model_name": "openai/gpt-5.5",
+        },
         "gpt-5": {
             "provider": "openai",
             "api_key_var": "OPENAI_API_KEY",

--- a/tasks/playwright/standard/eval_web/cloudflare_turnstile_challenge/description.md
+++ b/tasks/playwright/standard/eval_web/cloudflare_turnstile_challenge/description.md
@@ -20,4 +20,3 @@ Use Playwright MCP tools to complete Cloudflare Turnstile authentication challen
 - Use the provided test credentials: testuser / password123
 - Page shows success message inline, does not redirect to separate success page
 - Wait for all UI state changes before proceeding to next step
-- Verify both Turnstile completion and form submission success

--- a/tasks/playwright/standard/eval_web/cloudflare_turnstile_challenge/verify.py
+++ b/tasks/playwright/standard/eval_web/cloudflare_turnstile_challenge/verify.py
@@ -20,7 +20,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None

--- a/tasks/playwright/standard/eval_web/extraction_table/data.csv
+++ b/tasks/playwright/standard/eval_web/extraction_table/data.csv
@@ -1,98 +1,98 @@
 Title, Rating, Likes, Views, Replies
-React 18 New Features Deep Dive, "4.8", 856, 12543, 89
-Vue 3 Composition API in Practice, "4.5", 743, 9876, 67
-Advanced TypeScript Types Guide, "4.9", 924, 15432, 102
-Node.js Performance Optimization, "4.2", 567, 8765, 45
-Frontend Engineering Best Practices, "4.7", 812, 11234, 78
-Microservices Architecture Patterns, "4.3", 634, 9543, 56
-Docker Containerization Deployment, "4.6", 789, 10876, 71
-Kubernetes Cluster Management, "4.4", 698, 9234, 63
-GraphQL API Design Principles, "4.8", 876, 13456, 94
-Webpack 5 Configuration Guide, "4.1", 523, 7654, 38
-Vite Build Tool Usage, "4.5", 745, 10123, 69
-ESLint Code Standards, "4.7", 823, 11567, 82
-Unit Testing Best Practices, "4.3", 612, 8934, 51
-Performance Monitoring & Optimization, "4.9", 945, 16234, 108
-Security Protection Strategies, "4.2", 578, 8456, 47
-Database Design Principles, "4.6", 767, 10567, 73
-Caching Strategies Implementation, "4.4", 689, 9123, 61
-Message Queue Applications, "4.8", 834, 12876, 87
-Distributed Systems Design, "4.0", 456, 6789, 34
-Cloud Native Development, "4.5", 723, 9876, 65
-DevOps Process Optimization, "4.7", 801, 11234, 79
-Machine Learning Introduction, "4.1", 534, 7543, 41
-Artificial Intelligence Applications, "4.6", 778, 10456, 74
-Blockchain Technology Fundamentals, "4.3", 645, 8765, 53
-Mobile Development Techniques, "4.9", 912, 14567, 97
-Cross-Platform Solutions, "4.2", 589, 8234, 48
-Progressive Web App Development, "4.8", 867, 12345, 91
-Web3 Development Guide, "4.4", 712, 9567, 64
-NFT Smart Contracts, "4.5", 756, 10234, 70
-DeFi Protocol Design, "4.7", 834, 11876, 83
-Game Engine Development, "4.3", 623, 8567, 52
-3D Graphics Rendering, "4.6", 789, 10678, 75
-Audio Video Processing, "4.1", 545, 7234, 42
-IoT Applications, "4.8", 856, 12567, 88
-Edge Computing Practices, "4.2", 567, 8345, 46
-5G Network Technology, "4.9", 923, 15123, 103
-Quantum Computing Principles, "4.4", 678, 9345, 62
-Bioinformatics Analysis, "4.5", 734, 9876, 68
-Data Science Methods, "4.7", 812, 11456, 80
-Algorithms and Data Structures, "4.3", 634, 8678, 54
-System Design Interview, "4.6", 778, 10345, 76
-Code Refactoring Techniques, "4.8", 845, 12234, 89
-Open Source Contributions, "4.2", 556, 7890, 43
-Technical Team Management, "4.5", 723, 9567, 66
-Product Thinking Development, "4.9", 901, 14234, 95
-User Experience Design, "4.1", 512, 7123, 39
-Interface Interaction Optimization, "4.7", 789, 10890, 77
-Accessibility Design, "4.4", 667, 8901, 58
-SEO Optimization Strategies, "4.6", 756, 10123, 72
-Social Media Operations, "4.3", 623, 8456, 55
-Serverless Architecture, "4.7", 834, 11234, 81
-API Gateway Design, "4.2", 567, 8765, 49
-Microservice Communication, "4.8", 892, 13567, 95
-Event-Driven Architecture, "4.5", 723, 9876, 67
-CQRS Pattern Implementation, "4.3", 645, 8234, 54
-Domain-Driven Design, "4.6", 778, 10456, 73
-Clean Architecture Principles, "4.4", 689, 9123, 62
-Hexagonal Architecture, "4.1", 534, 7543, 42
-Onion Architecture, "4.5", 712, 9567, 65
-Event Sourcing Patterns, "4.7", 823, 11876, 79
-Saga Pattern for Distributed Systems, "4.3", 612, 8934, 53
-Circuit Breaker Pattern, "4.8", 856, 12543, 87
-Bulkhead Pattern, "4.2", 578, 8456, 47
-Retry Pattern Implementation, "4.6", 767, 10567, 74
-Timeout Pattern, "4.4", 698, 9234, 63
-Rate Limiting Strategies, "4.9", 934, 15432, 103
-Load Balancing Techniques, "4.1", 523, 7654, 39
-Service Mesh Architecture, "4.5", 745, 10123, 69
-Istio Service Mesh, "4.7", 812, 11567, 82
-Envoy Proxy Configuration, "4.3", 634, 9543, 56
-Consul Service Discovery, "4.6", 789, 10876, 71
-Kubernetes Ingress, "4.4", 676, 9345, 58
-Helm Chart Development, "4.8", 845, 12234, 89
-Terraform Infrastructure, "4.2", 556, 7890, 44
-Ansible Automation, "4.5", 723, 9567, 66
-Jenkins Pipeline, "4.7", 801, 11234, 78
-GitLab CI/CD, "4.3", 623, 8567, 52
-GitHub Actions, "4.6", 789, 10678, 75
-Azure DevOps, "4.1", 512, 7123, 41
-AWS CodePipeline, "4.8", 867, 12345, 91
-Docker Compose, "4.4", 712, 9567, 64
-Kubernetes Operators, "4.5", 756, 10234, 70
-Custom Resource Definitions, "4.7", 834, 11876, 83
-Pod Security Policies, "4.3", 623, 8567, 52
-Network Policies, "4.6", 789, 10678, 75
-RBAC Configuration, "4.1", 545, 7234, 42
-Secret Management, "4.8", 856, 12567, 88
-ConfigMap Usage, "4.2", 567, 8345, 46
-Persistent Volumes, "4.9", 923, 15123, 103
-StatefulSets, "4.4", 678, 9345, 62
-DaemonSets, "4.5", 734, 9876, 68
-Jobs and CronJobs, "4.7", 812, 11456, 80
-Horizontal Pod Autoscaler, "4.3", 634, 8678, 54
-Vertical Pod Autoscaler, "4.6", 778, 10345, 76
-Cluster Autoscaler, "4.8", 845, 12234, 89
-Resource Quotas, "4.2", 556, 7890, 43
-Limit Ranges, "4.5", 723, 9567, 66
+React 18 New Features Deep Dive, 4.8, 856, 12543, 89
+Vue 3 Composition API in Practice, 4.5, 743, 9876, 67
+Advanced TypeScript Types Guide, 4.9, 924, 15432, 102
+Node.js Performance Optimization, 4.2, 567, 8765, 45
+Frontend Engineering Best Practices, 4.7, 812, 11234, 78
+Microservices Architecture Patterns, 4.3, 634, 9543, 56
+Docker Containerization Deployment, 4.6, 789, 10876, 71
+Kubernetes Cluster Management, 4.4, 698, 9234, 63
+GraphQL API Design Principles, 4.8, 876, 13456, 94
+Webpack 5 Configuration Guide, 4.1, 523, 7654, 38
+Vite Build Tool Usage, 4.5, 745, 10123, 69
+ESLint Code Standards, 4.7, 823, 11567, 82
+Unit Testing Best Practices, 4.3, 612, 8934, 51
+Performance Monitoring & Optimization, 4.9, 945, 16234, 108
+Security Protection Strategies, 4.2, 578, 8456, 47
+Database Design Principles, 4.6, 767, 10567, 73
+Caching Strategies Implementation, 4.4, 689, 9123, 61
+Message Queue Applications, 4.8, 834, 12876, 87
+Distributed Systems Design, 4.0, 456, 6789, 34
+Cloud Native Development, 4.5, 723, 9876, 65
+DevOps Process Optimization, 4.7, 801, 11234, 79
+Machine Learning Introduction, 4.1, 534, 7543, 41
+Artificial Intelligence Applications, 4.6, 778, 10456, 74
+Blockchain Technology Fundamentals, 4.3, 645, 8765, 53
+Mobile Development Techniques, 4.9, 912, 14567, 97
+Cross-Platform Solutions, 4.2, 589, 8234, 48
+Progressive Web App Development, 4.8, 867, 12345, 91
+Web3 Development Guide, 4.4, 712, 9567, 64
+NFT Smart Contracts, 4.5, 756, 10234, 70
+DeFi Protocol Design, 4.7, 834, 11876, 83
+Game Engine Development, 4.3, 623, 8567, 52
+3D Graphics Rendering, 4.6, 789, 10678, 75
+Audio Video Processing, 4.1, 545, 7234, 42
+IoT Applications, 4.8, 856, 12567, 88
+Edge Computing Practices, 4.2, 567, 8345, 46
+5G Network Technology, 4.9, 923, 15123, 103
+Quantum Computing Principles, 4.4, 678, 9345, 62
+Bioinformatics Analysis, 4.5, 734, 9876, 68
+Data Science Methods, 4.7, 812, 11456, 80
+Algorithms and Data Structures, 4.3, 634, 8678, 54
+System Design Interview, 4.6, 778, 10345, 76
+Code Refactoring Techniques, 4.8, 845, 12234, 89
+Open Source Contributions, 4.2, 556, 7890, 43
+Technical Team Management, 4.5, 723, 9567, 66
+Product Thinking Development, 4.9, 901, 14234, 95
+User Experience Design, 4.1, 512, 7123, 39
+Interface Interaction Optimization, 4.7, 789, 10890, 77
+Accessibility Design, 4.4, 667, 8901, 58
+SEO Optimization Strategies, 4.6, 756, 10123, 72
+Social Media Operations, 4.3, 623, 8456, 55
+Serverless Architecture, 4.7, 834, 11234, 81
+API Gateway Design, 4.2, 567, 8765, 49
+Microservice Communication, 4.8, 892, 13567, 95
+Event-Driven Architecture, 4.5, 723, 9876, 67
+CQRS Pattern Implementation, 4.3, 645, 8234, 54
+Domain-Driven Design, 4.6, 778, 10456, 73
+Clean Architecture Principles, 4.4, 689, 9123, 62
+Hexagonal Architecture, 4.1, 534, 7543, 42
+Onion Architecture, 4.5, 712, 9567, 65
+Event Sourcing Patterns, 4.7, 823, 11876, 79
+Saga Pattern for Distributed Systems, 4.3, 612, 8934, 53
+Circuit Breaker Pattern, 4.8, 856, 12543, 87
+Bulkhead Pattern, 4.2, 578, 8456, 47
+Retry Pattern Implementation, 4.6, 767, 10567, 74
+Timeout Pattern, 4.4, 698, 9234, 63
+Rate Limiting Strategies, 4.9, 934, 15432, 103
+Load Balancing Techniques, 4.1, 523, 7654, 39
+Service Mesh Architecture, 4.5, 745, 10123, 69
+Istio Service Mesh, 4.7, 812, 11567, 82
+Envoy Proxy Configuration, 4.3, 634, 9543, 56
+Consul Service Discovery, 4.6, 789, 10876, 71
+Kubernetes Ingress, 4.4, 676, 9345, 58
+Helm Chart Development, 4.8, 845, 12234, 89
+Terraform Infrastructure, 4.2, 556, 7890, 44
+Ansible Automation, 4.5, 723, 9567, 66
+Jenkins Pipeline, 4.7, 801, 11234, 78
+GitLab CI/CD, 4.3, 623, 8567, 52
+GitHub Actions, 4.6, 789, 10678, 75
+Azure DevOps, 4.1, 512, 7123, 41
+AWS CodePipeline, 4.8, 867, 12345, 91
+Docker Compose, 4.4, 712, 9567, 64
+Kubernetes Operators, 4.5, 756, 10234, 70
+Custom Resource Definitions, 4.7, 834, 11876, 83
+Pod Security Policies, 4.3, 623, 8567, 52
+Network Policies, 4.6, 789, 10678, 75
+RBAC Configuration, 4.1, 545, 7234, 42
+Secret Management, 4.8, 856, 12567, 88
+ConfigMap Usage, 4.2, 567, 8345, 46
+Persistent Volumes, 4.9, 923, 15123, 103
+StatefulSets, 4.4, 678, 9345, 62
+DaemonSets, 4.5, 734, 9876, 68
+Jobs and CronJobs, 4.7, 812, 11456, 80
+Horizontal Pod Autoscaler, 4.3, 634, 8678, 54
+Vertical Pod Autoscaler, 4.6, 778, 10345, 76
+Cluster Autoscaler, 4.8, 845, 12234, 89
+Resource Quotas, 4.2, 556, 7890, 43
+Limit Ranges, 4.5, 723, 9567, 66

--- a/tasks/playwright/standard/eval_web/extraction_table/description.md
+++ b/tasks/playwright/standard/eval_web/extraction_table/description.md
@@ -20,11 +20,11 @@ Use Playwright MCP tools to extract all data from the specified website and pres
 
 ```csv
 Title, Rating, Likes, Views, Replies
-SEO Optimization, "4.6", 756, 10123, 72
-Vue 3 Composition API, "4.5", 743, 9876, 67
-Advanced TypeScript Types Guide, "4.9", 924, 15432, 102
-Node.js Performance Optimization, "4.2", 567, 8765, 45
-Frontend Engineering Best Practices, "4.7", 812, 11234, 78
+SEO Optimization, 4.6, 756, 10123, 72
+Vue 3 Composition API, 4.5, 743, 9876, 67
+Advanced TypeScript Types Guide, 4.9, 924, 15432, 102
+Node.js Performance Optimization, 4.2, 567, 8765, 45
+Frontend Engineering Best Practices, 4.7, 812, 11234, 78
 ```
 
 ## Notes:

--- a/tasks/playwright/standard/eval_web/extraction_table/verify.py
+++ b/tasks/playwright/standard/eval_web/extraction_table/verify.py
@@ -13,11 +13,26 @@ import re
 import csv
 from io import StringIO
 
-# Expected CSV header (must match exactly, including spaces)
-EXPECTED_HEADER_LINE = "Title, Rating, Likes, Views, Replies"
+# Expected CSV columns (order in output is flexible, but the set must match)
 EXPECTED_HEADERS = ["Title", "Rating", "Likes", "Views", "Replies"]
+
+
+def _load_expected_rows():
+    """Load ground-truth rows from data.csv as a set of normalized tuples."""
+    path = os.path.join(os.path.dirname(__file__), "data.csv")
+    expected = set()
+    with open(path, newline='') as f:
+        reader = csv.reader(f)
+        next(reader)  # skip header
+        for row in reader:
+            cells = [c.strip() for c in row]
+            expected.add((cells[0], float(cells[1]), int(cells[2]), int(cells[3]), int(cells[4])))
+    return expected
+
+
+EXPECTED_ROWS = _load_expected_rows()
 # Exact number of data rows (must match data.csv exactly)
-EXPECTED_DATA_ROWS = 97
+EXPECTED_DATA_ROWS = len(EXPECTED_ROWS)
 
 
 def get_model_response():
@@ -26,7 +41,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"| MCP_MESSAGES: {messages_path}")
+    print(f"| MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("| Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None
@@ -71,9 +86,9 @@ def extract_csv_from_response(response):
     lines = response.split('\n')
     csv_start = -1
 
-    # Stricter header matching: look for lines containing "Title" and "Rating"
+    # Stricter header matching: look for lines containing all expected column names
     for i, line in enumerate(lines):
-        if "Title" in line and "Rating" in line and "Likes" in line:
+        if all(h in line for h in EXPECTED_HEADERS):
             csv_start = i
             break
 
@@ -110,11 +125,6 @@ def validate_csv_data(csv_text):
         if len(lines) != expected_total_rows:
             return False, f"| CSV total row count mismatch, expected: {expected_total_rows} rows, actual: {len(lines)} rows"
 
-        # Check header row format (must match exactly)
-        header_line = lines[0].strip()
-        if header_line != EXPECTED_HEADER_LINE:
-            return False, f"| Header format mismatch, expected: '{EXPECTED_HEADER_LINE}', actual: '{header_line}'"
-
         # Parse CSV to validate structure
         csv_reader = csv.reader(StringIO(csv_text))
         rows = list(csv_reader)
@@ -125,16 +135,25 @@ def validate_csv_data(csv_text):
             if len(row) != expected_columns:
                 return False, f"| Row {i+1} column count incorrect, expected: {expected_columns} columns, actual: {len(row)} columns"
 
+        # Check header columns — order can vary, but the set must match exactly
+        header_cells = [c.strip() for c in rows[0]]
+        if set(header_cells) != set(EXPECTED_HEADERS):
+            missing_h = set(EXPECTED_HEADERS) - set(header_cells)
+            extra_h = set(header_cells) - set(EXPECTED_HEADERS)
+            return False, f"| Header columns mismatch, missing: {sorted(missing_h)}, extra: {sorted(extra_h)}"
+        col_idx = {name: i for i, name in enumerate(header_cells)}
+
         # Validate data row format
         valid_rows = 0
+        seen = set()
         for i, row in enumerate(rows[1:], 2):  # Skip header, start from row 2
             # Check if each column has data
             if not all(cell.strip() for cell in row):
                 return False, f"| Row {i} contains empty data"
 
             # Check numeric column format (Rating, Likes, Views, Replies should not have quotes)
-            for col_idx, col_name in [(1, "Rating"), (2, "Likes"), (3, "Views"), (4, "Replies")]:
-                value = row[col_idx].strip()
+            for col_name in ("Rating", "Likes", "Views", "Replies"):
+                value = row[col_idx[col_name]].strip()
 
                 # Check for quotes (should not have any)
                 if value.startswith('"') and value.endswith('"'):
@@ -150,11 +169,24 @@ def validate_csv_data(csv_text):
                     if not value.isdigit():
                         return False, f"| Row {i} {col_name} should be pure digits, actual: {value}"
 
+            seen.add((
+                row[col_idx["Title"]].strip(),
+                float(row[col_idx["Rating"]].strip()),
+                int(row[col_idx["Likes"]].strip()),
+                int(row[col_idx["Views"]].strip()),
+                int(row[col_idx["Replies"]].strip()),
+            ))
             valid_rows += 1
 
         # Validate number of data rows
         if valid_rows != EXPECTED_DATA_ROWS:
             return False, f"| Valid data row count mismatch, expected: {EXPECTED_DATA_ROWS} rows, actual: {valid_rows} rows"
+
+        # Validate row contents match data.csv exactly (order independent)
+        missing = EXPECTED_ROWS - seen
+        extra = seen - EXPECTED_ROWS
+        if missing or extra:
+            return False, f"| Row content mismatch, missing: {len(missing)} row(s), extra: {len(extra)} row(s); sample missing: {sorted(missing)[:2]}"
 
         return True, f"| CSV validation successful: format matches data.csv exactly, {valid_rows} valid data rows"
 

--- a/tasks/playwright/standard/web_search/birth_of_arvinxu/description.md
+++ b/tasks/playwright/standard/web_search/birth_of_arvinxu/description.md
@@ -4,5 +4,4 @@ Use Playwright MCP tools to search for information about the X profile https://x
 
 ## Requirements:
 
-Extract the answer in specific format:
-   - just year,like 1990, 2001
+Output ONLY the 4-digit birth year (e.g. `1990`, `2001`), with no other text — no prose, units, punctuation, quotes, or surrounding whitespace.

--- a/tasks/playwright/standard/web_search/birth_of_arvinxu/verify.py
+++ b/tasks/playwright/standard/web_search/birth_of_arvinxu/verify.py
@@ -63,22 +63,29 @@ def parse_ai_results(work_dir: Path) -> Dict[str, Any]:
     found_answer = False
     ai_responses = []
 
-    for message in messages:
-        if message.get("role") == "assistant":
-            content = str(message.get("content", ""))
+    # Find the last completed assistant message
+    for message in reversed(messages):
+        if (message.get("role") == "assistant" and
+            message.get("status") == "completed" and
+            message.get("type") == "message"):
+            content = ""
 
             # Handle both string and list content formats
-            if isinstance(message.get("content"), list):
-                content = " ".join(
-                    item.get("text", "") if isinstance(item, dict) else str(item)
-                    for item in message.get("content", [])
-                )
+            raw = message.get("content", "")
+            if isinstance(raw, list):
+                for item in raw:
+                    if isinstance(item, dict) and item.get("type") in ["text", "output_text"]:
+                        content = item.get("text", "")
+                        break
+            elif isinstance(raw, str):
+                content = raw
 
             ai_responses.append(content)
 
             # Exact match (character-for-character, case-sensitive, no trimming)
             if content == EXPECTED_GROUND_TRUTH:
                 found_answer = True
+            break
 
     return {
         "success": True,

--- a/tasks/playwright/standard/web_search/r1_arxiv/description.md
+++ b/tasks/playwright/standard/web_search/r1_arxiv/description.md
@@ -1,20 +1,20 @@
 # Web Search Task
 
-Use Playwright MCP tools to search for the **v1 (initial) version** of the DeepSeek R1 research paper on arXiv and extract all the paragraphs of the Conclusion section.
+Use Playwright MCP tools to search for the **v1 (initial) version** of the DeepSeek R1 research paper on arXiv and extract all the paragraphs of the "Conclusion, Limitations, and Future Work" section.
 
 ## Requirements:
 
 1. Search for the DeepSeek R1 research paper on arXiv
 2. Navigate to the **v1 (initial) version** of the paper
-3. Find the Conclusion section
-4. Extract **ALL the paragraphs** of the Conclusion section
+3. Find the "Conclusion, Limitations, and Future Work" section
+4. Extract **ALL the paragraphs** of the "Conclusion, Limitations, and Future Work" section
 5. **Provide the content in Markdown format - no explanations, no additional text**
 
 ## Important Notes:
 
 - **Output ALL the paragraphs of text**
 - **Do NOT include any explanations, summaries, or additional content**
-- **The response should contain ONLY the Conclusion section content formatted in Markdown**
+- **The response should contain ONLY the "Conclusion, Limitations, and Future Work" section content formatted in Markdown**
 
 ## Expected Output:
-All the paragraphs of the Conclusion section from the DeepSeek R1 paper, formatted in Markdown with proper paragraph structure and formatting.
+All the paragraphs of the "Conclusion, Limitations, and Future Work" section from the DeepSeek R1 paper, formatted in Markdown with proper paragraph structure and formatting.

--- a/tasks/playwright/standard/web_search/r1_arxiv/description.md
+++ b/tasks/playwright/standard/web_search/r1_arxiv/description.md
@@ -1,13 +1,14 @@
 # Web Search Task
 
-Use Playwright MCP tools to search for the DeepSeek R1 research paper and extract all the paragraphs of the Conclusion section.
+Use Playwright MCP tools to search for the **v1 (initial) version** of the DeepSeek R1 research paper on arXiv and extract all the paragraphs of the Conclusion section.
 
 ## Requirements:
 
-1. Search for the DeepSeek R1 research paper
-2. Navigate to the paper and find the Conclusion section
-3. Extract **ALL the paragraphs** of the Conclusion section
-4. **Provide the content in Markdown format - no explanations, no additional text**
+1. Search for the DeepSeek R1 research paper on arXiv
+2. Navigate to the **v1 (initial) version** of the paper
+3. Find the Conclusion section
+4. Extract **ALL the paragraphs** of the Conclusion section
+5. **Provide the content in Markdown format - no explanations, no additional text**
 
 ## Important Notes:
 

--- a/tasks/playwright/standard/web_search/r1_arxiv/verify.py
+++ b/tasks/playwright/standard/web_search/r1_arxiv/verify.py
@@ -9,6 +9,9 @@ The expected ground truth answer is configured at the top of the file.
 import sys
 import json
 import os
+import re
+import difflib
+import unicodedata
 from pathlib import Path
 from typing import Dict, Any
 
@@ -18,6 +21,28 @@ from typing import Dict, Any
 
 # Expected ground truth content from content.txt
 EXPECTED_CONTENT_FILE = "content.txt"
+
+# Similarity threshold for content match (after normalization)
+SIMILARITY_THRESHOLD = 0.9
+
+
+def _normalize_content(s: str) -> str:
+    """Strip markdown / unicode / whitespace noise so comparison focuses on text content."""
+    # Strip bold markers
+    s = re.sub(r'\*\*|__', '', s)
+    # Strip leading list markers and numbered items
+    s = re.sub(r'^[\s]*[-*+]\s+', '', s, flags=re.M)
+    s = re.sub(r'^[\s]*\d+\.\s+', '', s, flags=re.M)
+    # Unicode-normalize and collapse smart quotes / dashes to ASCII
+    s = unicodedata.normalize('NFKC', s)
+    s = s.translate(str.maketrans({
+        '‘': "'", '’': "'",
+        '“': '"', '”': '"',
+        '–': '-', '—': '-',
+    }))
+    # Collapse whitespace, lowercase
+    s = re.sub(r'\s+', ' ', s).strip().lower()
+    return s
 
 # =============================================================================
 # MCP RESULT PARSING
@@ -84,21 +109,28 @@ def parse_ai_results(work_dir: Path) -> Dict[str, Any]:
     ai_responses = []
     extracted_content = ""
 
-    for message in messages:
-        if message.get("role") == "assistant":
-            content = str(message.get("content", ""))
+    # Find the last completed assistant message
+    for message in reversed(messages):
+        if (message.get("role") == "assistant" and
+            message.get("status") == "completed" and
+            message.get("type") == "message"):
+            content = ""
 
             # Handle both string and list content formats
-            if isinstance(message.get("content"), list):
-                content = " ".join(
-                    item.get("text", "") if isinstance(item, dict) else str(item)
-                    for item in message.get("content", [])
-                )
+            raw = message.get("content", "")
+            if isinstance(raw, list):
+                for item in raw:
+                    if isinstance(item, dict) and item.get("type") in ["text", "output_text"]:
+                        content = item.get("text", "")
+                        break
+            elif isinstance(raw, str):
+                content = raw
 
             ai_responses.append(content)
 
             # Store the last response as extracted content
             extracted_content = content
+            break
 
     return {
         "success": True,
@@ -117,16 +149,19 @@ def compare_content(extracted: str, expected: str) -> Dict[str, Any]:
     if not extracted:
         return {"success": False, "error": "No extracted content found"}
 
-    # Normalize content for comparison (remove extra whitespace, normalize line breaks)
-    extracted_normalized = " ".join(extracted.split())
-    expected_normalized = " ".join(expected.split())
+    # Normalize markdown / unicode / whitespace noise on both sides
+    extracted_normalized = _normalize_content(extracted)
+    expected_normalized = _normalize_content(expected)
 
-    # Direct text comparison - content must be exactly the same
-    is_exact_match = extracted_normalized == expected_normalized
+    # Similarity-based comparison; threshold tolerates small residual noise
+    similarity = difflib.SequenceMatcher(None, expected_normalized, extracted_normalized).ratio()
+    is_exact_match = similarity >= SIMILARITY_THRESHOLD
 
     return {
         "success": True,
         "is_exact_match": is_exact_match,
+        "similarity": similarity,
+        "threshold": SIMILARITY_THRESHOLD,
         "extracted_length": len(extracted_normalized),
         "expected_length": len(expected_normalized),
         "extracted_preview": extracted_normalized[:100] + "..." if len(extracted_normalized) > 100 else extracted_normalized,
@@ -181,14 +216,15 @@ def verify_task(work_dir: Path) -> bool:
     print(f"| Content comparison results:")
     print(f"|   - Extracted length: {comparison['extracted_length']} characters")
     print(f"|   - Expected length: {comparison['expected_length']} characters")
+    print(f"|   - Similarity: {comparison['similarity']:.4f} (threshold: {comparison['threshold']})")
     print(f"|   - Extracted preview: {comparison['extracted_preview']}")
     print(f"|   - Expected preview: {comparison['expected_preview']}")
 
     if comparison['is_exact_match']:
-        print("| Task completed successfully! Content matches exactly.")
+        print(f"| Task completed successfully! Similarity {comparison['similarity']:.4f} >= {comparison['threshold']}.")
         return True
     else:
-        print("| Task verification failed. Content does not match exactly.")
+        print(f"| Task verification failed. Similarity {comparison['similarity']:.4f} < {comparison['threshold']}.")
         return False
 
 

--- a/tasks/playwright_webarena/standard/reddit/ai_data_analyst/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/ai_data_analyst/verify.py
@@ -51,14 +51,10 @@ def parse_key_value_format(text):
 
 def normalize_text(text):
     """
-    Normalize text for comparison by handling different quote styles and whitespace.
+    Normalize text for comparison by collapsing whitespace.
     """
     if not isinstance(text, str):
         return str(text)
-
-    # Replace various quote styles with standard quotes
-    text = text.replace(""", "'").replace(""", "'")
-    text = text.replace('"', '"').replace('"', '"')
 
     # Normalize whitespace
     text = " ".join(text.split())
@@ -181,13 +177,18 @@ async def verify() -> bool:
             extracted_data = parse_key_value_format(post_content)
             print(f"Extracted data: {extracted_data}", file=sys.stderr)
 
-            # Load expected values from label.txt
+            # Load expected values from label.txt — hard fail if missing
             label_path = Path(__file__).parent / "label.txt"
-            if label_path.exists():
-                with open(label_path, "r") as f:
-                    expected_text = f.read().strip()
-                expected_data = parse_key_value_format(expected_text)
-                print("Loaded expected values from label.txt", file=sys.stderr)
+            if not label_path.exists():
+                print(
+                    f"FAILED: Ground-truth file not found at {label_path}",
+                    file=sys.stderr,
+                )
+                return False
+            with open(label_path, "r") as f:
+                expected_text = f.read().strip()
+            expected_data = parse_key_value_format(expected_text)
+            print("Loaded expected values from label.txt", file=sys.stderr)
 
             # Verify all required keys are present
             required_keys = [
@@ -207,7 +208,7 @@ async def verify() -> bool:
 
             if missing_keys:
                 print(
-                    "FAILED: Missing required keys in submission: {', '.join(missing_keys)}",
+                    f"FAILED: Missing required keys in submission: {', '.join(missing_keys)}",
                     file=sys.stderr,
                 )
                 print(
@@ -219,64 +220,35 @@ async def verify() -> bool:
             # Validate data format and content
             errors = []
 
-            # Check numeric fields
-            try:
-                post_count = int(extracted_data["Deeplearning_Post_Count"])
-                if (
-                    "expected_data" in locals()
-                    and "Deeplearning_Post_Count" in expected_data
-                ):
-                    expected_count = int(expected_data["Deeplearning_Post_Count"])
-                    if post_count != expected_count:
-                        errors.append(
-                            f"Deeplearning_Post_Count mismatch: got {post_count}, expected {expected_count}"
-                        )
-            except ValueError:
-                errors.append(
-                    f"Deeplearning_Post_Count must be a number, got: {extracted_data['Deeplearning_Post_Count']}"
-                )
+            # Compare each field against expected_data
+            for key in required_keys:
+                if key in expected_data and key in extracted_data:
+                    expected_val = normalize_text(expected_data[key])
+                    actual_val = normalize_text(extracted_data[key])
 
-            # If we have expected data, compare against it
-            if "expected_data" in locals():
-                # Compare each field
-                for key in required_keys:
-                    if key in expected_data and key in extracted_data:
-                        expected_val = normalize_text(expected_data[key])
-                        actual_val = normalize_text(extracted_data[key])
-
-                        # For numeric fields, compare as integers
-                        if key in [
-                            "Deeplearning_Post_Count",
-                            "ChatGPT_Tool_Vote_Count",
-                            "Page2_Top_Post_Votes",
-                        ]:
-                            try:
-                                expected_int = int(expected_val)
-                                actual_int = int(actual_val)
-                                if expected_int != actual_int:
-                                    errors.append(
-                                        f"{key} mismatch: got {actual_int}, expected {expected_int}"
-                                    )
-                            except ValueError:
+                    # For numeric fields, compare as integers
+                    if key in [
+                        "Deeplearning_Post_Count",
+                        "ChatGPT_Tool_Vote_Count",
+                        "Page2_Top_Post_Votes",
+                    ]:
+                        try:
+                            expected_int = int(expected_val)
+                            actual_int = int(actual_val)
+                            if expected_int != actual_int:
                                 errors.append(
-                                    f"{key} should be numeric: got '{actual_val}'"
+                                    f"{key} mismatch: got {actual_int}, expected {expected_int}"
                                 )
-                        else:
-                            # For text fields, compare normalized text
-                            if expected_val != actual_val:
-                                errors.append(
-                                    f"{key} mismatch: got '{actual_val}', expected '{expected_val}'"
-                                )
-
-            else:
-                # If no expected data, just do basic validation
-                for key in required_keys:
-                    if key not in extracted_data:
-                        errors.append(f"Missing required key: {key}")
-                    elif (
-                        not extracted_data[key] or extracted_data[key] == "[FILL_VALUE]"
-                    ):
-                        errors.append(f"{key} was not filled in")
+                        except ValueError:
+                            errors.append(
+                                f"{key} should be numeric: got '{actual_val}'"
+                            )
+                    else:
+                        # For text fields, compare normalized text
+                        if expected_val != actual_val:
+                            errors.append(
+                                f"{key} mismatch: got '{actual_val}', expected '{expected_val}'"
+                            )
 
             if errors:
                 print(
@@ -286,10 +258,9 @@ async def verify() -> bool:
                 for error in errors:
                     print(f"  - {error}", file=sys.stderr)
                 print("\nExpected values from label.txt:", file=sys.stderr)
-                if "expected_data" in locals():
-                    for key in required_keys:
-                        if key in expected_data:
-                            print(f"  {key}: {expected_data[key]}", file=sys.stderr)
+                for key in required_keys:
+                    if key in expected_data:
+                        print(f"  {key}: {expected_data[key]}", file=sys.stderr)
                 return False
 
             # All checks passed

--- a/tasks/playwright_webarena/standard/reddit/ai_data_analyst/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/ai_data_analyst/verify.py
@@ -56,6 +56,9 @@ def normalize_text(text):
     if not isinstance(text, str):
         return str(text)
 
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
     # Normalize whitespace
     text = " ".join(text.split())
 

--- a/tasks/playwright_webarena/standard/reddit/budget_europe_travel/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/budget_europe_travel/verify.py
@@ -7,6 +7,23 @@ from playwright.async_api import async_playwright, TimeoutError as PlaywrightTim
 
 BASE_URL = os.getenv("WEBARENA_BASE_URL", "http://localhost:9999").rstrip("/")
 
+
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 async def verify() -> bool:
     """
     Verifies that the budget Europe travel resource task has been completed correctly.
@@ -176,7 +193,7 @@ async def verify() -> bool:
                     wiki_title_elem = page.locator(selector)
                     if await wiki_title_elem.count():
                         title_text = await wiki_title_elem.first.text_content()
-                        if title_text and title_text.strip() == expected_wiki_title:
+                        if title_text and normalize_text(title_text) == normalize_text(expected_wiki_title):
                             wiki_title_found = True
                             break
                 

--- a/tasks/playwright_webarena/standard/reddit/budget_europe_travel/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/budget_europe_travel/verify.py
@@ -257,8 +257,10 @@ async def verify() -> bool:
             else:
                 print("✓ On search results page for 'travel insurance Europe'", file=sys.stderr)
                 
-                # Check for "Retract upvote" button (only present when current user has upvoted)
-                retract_buttons = page.locator('button:has-text("Retract upvote")')
+                # Postmill renders vote buttons as icon-only (no text node), so
+                # match the title attribute. The title flips from "Upvote" to
+                # "Retract upvote" when the current user has upvoted.
+                retract_buttons = page.locator('button[title="Retract upvote"]')
                 if await retract_buttons.count() > 0:
                     print("✓ Found upvoted post (Retract upvote button present)", file=sys.stderr)
                 else:

--- a/tasks/playwright_webarena/standard/reddit/budget_europe_travel/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/budget_europe_travel/verify.py
@@ -7,23 +7,6 @@ from playwright.async_api import async_playwright, TimeoutError as PlaywrightTim
 
 BASE_URL = os.getenv("WEBARENA_BASE_URL", "http://localhost:9999").rstrip("/")
 
-def normalize_text(text):
-    """
-    Normalize text for comparison by handling different quote styles and whitespace.
-    """
-    if not isinstance(text, str):
-        return str(text)
-    
-    # Replace various quote styles with standard quotes
-    text = text.replace('\'', "'").replace('\'', "'")
-    text = text.replace('"', '"').replace('"', '"')
-    text = text.replace('&amp;', '&')
-    
-    # Normalize whitespace
-    text = ' '.join(text.split())
-    
-    return text.strip()
-
 async def verify() -> bool:
     """
     Verifies that the budget Europe travel resource task has been completed correctly.
@@ -193,7 +176,7 @@ async def verify() -> bool:
                     wiki_title_elem = page.locator(selector)
                     if await wiki_title_elem.count():
                         title_text = await wiki_title_elem.first.text_content()
-                        if expected_wiki_title in title_text:
+                        if title_text and title_text.strip() == expected_wiki_title:
                             wiki_title_found = True
                             break
                 
@@ -257,37 +240,11 @@ async def verify() -> bool:
             else:
                 print("✓ On search results page for 'travel insurance Europe'", file=sys.stderr)
                 
-                # Check for upvoted posts
-                upvote_found = False
-                
-                # Method 1: Check for "Retract upvote" button (indicates user has upvoted)
+                # Check for "Retract upvote" button (only present when current user has upvoted)
                 retract_buttons = page.locator('button:has-text("Retract upvote")')
                 if await retract_buttons.count() > 0:
                     print("✓ Found upvoted post (Retract upvote button present)", file=sys.stderr)
-                    upvote_found = True
-                
-                # Method 2: Check for posts with upvote count >= 1
-                if not upvote_found:
-                    # Look for vote counts
-                    vote_elements = page.locator('div.vote, span.vote-count, [class*="vote"]')
-                    
-                    for i in range(await vote_elements.count()):
-                        vote_elem = vote_elements.nth(i)
-                        vote_text = await vote_elem.text_content()
-                        try:
-                            # Extract number from vote text
-                            import re
-                            numbers = re.findall(r'\d+', vote_text)
-                            if numbers:
-                                vote_count = int(numbers[0])
-                                if vote_count >= 1:
-                                    print(f"✓ Found post with {vote_count} upvote(s)", file=sys.stderr)
-                                    upvote_found = True
-                                    break
-                        except:
-                            continue
-                
-                if not upvote_found:
+                else:
                     print("❌ ERROR: No upvoted posts found in search results", file=sys.stderr)
                     verification_passed = False
             

--- a/tasks/playwright_webarena/standard/reddit/buyitforlife_research/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/buyitforlife_research/verify.py
@@ -36,14 +36,10 @@ def parse_markdown_list_format(text):
 
 def normalize_text(text):
     """
-    Normalize text for comparison by handling different quote styles and whitespace.
+    Normalize text for comparison by collapsing whitespace.
     """
     if not isinstance(text, str):
         return str(text)
-
-    # Replace various quote styles with standard quotes
-    text = text.replace(""", "'").replace(""", "'")
-    text = text.replace('"', '"').replace('"', '"')
 
     # Normalize whitespace
     text = " ".join(text.split())
@@ -264,17 +260,6 @@ async def verify() -> bool:
                             if expected_val != actual_val:
                                 errors.append(f"{key} mismatch: got '{actual_val}', expected '{expected_val}'")
             
-            # Verify upvotes are in descending order
-            try:
-                post1_votes = int(extracted_data["Post1_Upvotes"])
-                post2_votes = int(extracted_data["Post2_Upvotes"])
-                post3_votes = int(extracted_data["Post3_Upvotes"])
-                
-                if not (post1_votes >= post2_votes >= post3_votes):
-                    errors.append(f"Posts should be ordered by upvotes: {post1_votes} >= {post2_votes} >= {post3_votes}")
-            except (ValueError, KeyError):
-                pass  # Already reported above
-            
             if errors:
                 print("Error: Validation failed with the following issues:", file=sys.stderr)
                 for error in errors:
@@ -287,7 +272,6 @@ async def verify() -> bool:
             print("✓ Submission 'Research Report for BuyItForLife' found in correct forum", file=sys.stderr)
             print("✓ All 14 required fields present and correct", file=sys.stderr)
             print("✓ Data matches expected values from label.txt", file=sys.stderr)
-            print("✓ Posts ordered by upvotes (descending)", file=sys.stderr)
             return True
             
         except PlaywrightTimeoutError as e:

--- a/tasks/playwright_webarena/standard/reddit/buyitforlife_research/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/buyitforlife_research/verify.py
@@ -41,6 +41,9 @@ def normalize_text(text):
     if not isinstance(text, str):
         return str(text)
 
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
     # Normalize whitespace
     text = " ".join(text.split())
 

--- a/tasks/playwright_webarena/standard/reddit/llm_research_summary/description.md
+++ b/tasks/playwright_webarena/standard/reddit/llm_research_summary/description.md
@@ -21,13 +21,13 @@ I need you to perform a comprehensive analysis of Large Language Model discussio
 - Total_LLM_Posts|FILL_VALUE
 - Top1_Title|FILL_VALUE
 - Top1_Upvotes|FILL_VALUE
-- Top1_Date|FILL_VALUE
+- Top1_Author|FILL_VALUE
 - Top2_Title|FILL_VALUE
 - Top2_Upvotes|FILL_VALUE
-- Top2_Date|FILL_VALUE
+- Top2_Author|FILL_VALUE
 - Top3_Title|FILL_VALUE
 - Top3_Upvotes|FILL_VALUE
-- Top3_Date|FILL_VALUE
+- Top3_Author|FILL_VALUE
 - Deeplearning_MostDiscussed|FILL_VALUE
 - Deeplearning_Comments|FILL_VALUE
 ```

--- a/tasks/playwright_webarena/standard/reddit/llm_research_summary/label.txt
+++ b/tasks/playwright_webarena/standard/reddit/llm_research_summary/label.txt
@@ -1,12 +1,12 @@
-- Total_LLM_Posts|9
+- Total_LLM_Posts|8
 - Top1_Title|[P] I made a command-line tool that explains your errors using ChatGPT (link in comments)
 - Top1_Upvotes|2655
-- Top1_Date|3 years ago
+- Top1_Author|jsonathan
 - Top2_Title|[P] I built Adrenaline, a debugger that fixes errors and explains them with GPT-3
 - Top2_Upvotes|1542
-- Top2_Date|3 years ago
+- Top2_Author|jsonathan
 - Top3_Title|[N] OpenAI may have benchmarked GPT-4's coding ability on it's own training data
 - Top3_Upvotes|925
-- Top3_Date|2 years ago
+- Top3_Author|Balance-
 - Deeplearning_MostDiscussed|Do companies actually care about their model's training/inference speed?
 - Deeplearning_Comments|39

--- a/tasks/playwright_webarena/standard/reddit/llm_research_summary/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/llm_research_summary/verify.py
@@ -49,6 +49,9 @@ def normalize_text(text):
     if not isinstance(text, str):
         return str(text)
 
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
     # Normalize whitespace
     text = " ".join(text.split())
 

--- a/tasks/playwright_webarena/standard/reddit/llm_research_summary/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/llm_research_summary/verify.py
@@ -15,51 +15,39 @@ BASE_URL = os.getenv("WEBARENA_BASE_URL", "http://localhost:9999").rstrip("/")
 def parse_key_value_format(text):
     """
     Parse the Key|Value format from the submission body.
-    Handles both pipe (|) and colon (:) separators for compatibility.
     """
     data = {}
-    
-    # Try to parse with pipe separator first (expected format)
+
     lines = text.strip().split('\n')
     for line in lines:
         line = line.strip()
         if not line:
             continue
-        
+
         # Remove markdown list prefix if present
         if line.startswith('- '):
             line = line[2:]
         elif line.startswith('* '):
             line = line[2:]
-        
-        # Try pipe separator first
+        elif line.startswith('• '):
+            line = line[2:]
+
         if '|' in line:
             parts = line.split('|', 1)
             if len(parts) == 2:
                 key = parts[0].strip()
                 value = parts[1].strip()
                 data[key] = value
-        # Fallback to colon separator for label.txt compatibility
-        elif ':' in line:
-            parts = line.split(':', 1)
-            if len(parts) == 2:
-                key = parts[0].strip()
-                value = parts[1].strip()
-                data[key] = value
-    
+
     return data
 
 
 def normalize_text(text):
     """
-    Normalize text for comparison by handling different quote styles and whitespace.
+    Normalize text for comparison by collapsing whitespace.
     """
     if not isinstance(text, str):
         return str(text)
-
-    # Replace various quote styles with standard quotes
-    text = text.replace(""", "'").replace(""", "'")
-    text = text.replace('"', '"').replace('"', '"')
 
     # Normalize whitespace
     text = " ".join(text.split())
@@ -168,26 +156,31 @@ async def verify() -> bool:
             extracted_data = parse_key_value_format(post_content)
             print(f"Extracted data: {extracted_data}", file=sys.stderr)
 
-            # Load expected values from label.txt
+            # Load expected values from label.txt — hard fail if missing
             label_path = Path(__file__).parent / "label.txt"
-            if label_path.exists():
-                with open(label_path, "r") as f:
-                    expected_text = f.read().strip()
-                expected_data = parse_key_value_format(expected_text)
-                print("Loaded expected values from label.txt", file=sys.stderr)
+            if not label_path.exists():
+                print(
+                    f"Error: Ground-truth file not found at {label_path}",
+                    file=sys.stderr,
+                )
+                return False
+            with open(label_path, "r") as f:
+                expected_text = f.read().strip()
+            expected_data = parse_key_value_format(expected_text)
+            print("Loaded expected values from label.txt", file=sys.stderr)
 
             # Verify all required keys are present
             required_keys = [
                 "Total_LLM_Posts",
                 "Top1_Title",
                 "Top1_Upvotes",
-                "Top1_Date",
+                "Top1_Author",
                 "Top2_Title",
                 "Top2_Upvotes",
-                "Top2_Date",
+                "Top2_Author",
                 "Top3_Title",
                 "Top3_Upvotes",
-                "Top3_Date",
+                "Top3_Author",
                 "Deeplearning_MostDiscussed",
                 "Deeplearning_Comments",
             ]
@@ -204,79 +197,36 @@ async def verify() -> bool:
                 )
                 return False
 
-            # Validate data format and content
+            # Compare each field against expected_data
             errors = []
+            for key in required_keys:
+                if key in expected_data and key in extracted_data:
+                    expected_val = normalize_text(expected_data[key])
+                    actual_val = normalize_text(extracted_data[key])
 
-            # Check Total_LLM_Posts is a number and matches expected
-            try:
-                total_posts = int(extracted_data["Total_LLM_Posts"])
-                if "expected_data" in locals() and "Total_LLM_Posts" in expected_data:
-                    expected_total = int(expected_data["Total_LLM_Posts"])
-                    if total_posts != expected_total:
-                        errors.append(
-                            f"Total_LLM_Posts mismatch: got {total_posts}, expected {expected_total}"
-                        )
-                elif total_posts < 5:  # Based on exploration, should be at least 5
-                    errors.append(f"Total_LLM_Posts seems too low: {total_posts}")
-            except ValueError:
-                errors.append(
-                    f"Total_LLM_Posts must be a number, got: {extracted_data['Total_LLM_Posts']}"
-                )
-
-            # If we have expected data, compare against it
-            if "expected_data" in locals():
-                # Compare each field
-                for key in required_keys:
-                    if key in expected_data and key in extracted_data:
-                        expected_val = normalize_text(expected_data[key])
-                        actual_val = normalize_text(extracted_data[key])
-
-                        # For numeric fields, compare as integers
-                        if (
-                            "Upvotes" in key
-                            or "Comments" in key
-                            or key == "Total_LLM_Posts"
-                        ):
-                            try:
-                                expected_int = int(expected_val)
-                                actual_int = int(actual_val)
-                                if expected_int != actual_int:
-                                    errors.append(
-                                        f"{key} mismatch: got {actual_int}, expected {expected_int}"
-                                    )
-                            except ValueError:
-                                errors.append(
-                                    f"{key} should be numeric: got '{actual_val}'"
-                                )
-                        else:
-                            # For text fields, compare normalized text
-                            if expected_val != actual_val:
-                                errors.append(
-                                    f"{key} mismatch: got '{actual_val}', expected '{expected_val}'"
-                                )
-
-            else:
-                # If no expected data, just do basic validation
-                for key in required_keys:
-                    if key not in extracted_data:
-                        errors.append(f"Missing required key: {key}")
-                    elif (
-                        not extracted_data[key] or extracted_data[key] == "[FILL_VALUE]"
+                    # For numeric fields, compare as integers
+                    if (
+                        "Upvotes" in key
+                        or "Comments" in key
+                        or key == "Total_LLM_Posts"
                     ):
-                        errors.append(f"{key} was not filled in")
-
-            # Verify upvotes are in descending order for top 3
-            try:
-                top1_votes = int(extracted_data["Top1_Upvotes"])
-                top2_votes = int(extracted_data["Top2_Upvotes"])
-                top3_votes = int(extracted_data["Top3_Upvotes"])
-
-                if not (top1_votes >= top2_votes >= top3_votes):
-                    errors.append(
-                        f"Top posts should be ordered by upvotes: {top1_votes} >= {top2_votes} >= {top3_votes}"
-                    )
-            except (ValueError, KeyError):
-                pass  # Already reported above
+                        try:
+                            expected_int = int(expected_val)
+                            actual_int = int(actual_val)
+                            if expected_int != actual_int:
+                                errors.append(
+                                    f"{key} mismatch: got {actual_int}, expected {expected_int}"
+                                )
+                        except ValueError:
+                            errors.append(
+                                f"{key} should be numeric: got '{actual_val}'"
+                            )
+                    else:
+                        # For text fields, compare normalized text
+                        if expected_val != actual_val:
+                            errors.append(
+                                f"{key} mismatch: got '{actual_val}', expected '{expected_val}'"
+                            )
 
             if errors:
                 print(

--- a/tasks/playwright_webarena/standard/reddit/movie_reviewer_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/movie_reviewer_analysis/verify.py
@@ -60,6 +60,9 @@ def normalize_text(text):
     # Decode &amp; HTML entity
     text = text.replace("&amp;", "&")
 
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
     # Normalize whitespace
     text = " ".join(text.split())
 

--- a/tasks/playwright_webarena/standard/reddit/movie_reviewer_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/movie_reviewer_analysis/verify.py
@@ -52,14 +52,12 @@ def parse_key_value_format(text):
 
 def normalize_text(text):
     """
-    Normalize text for comparison by handling different quote styles and whitespace.
+    Normalize text for comparison by decoding the &amp; HTML entity and collapsing whitespace.
     """
     if not isinstance(text, str):
         return str(text)
 
-    # Replace various quote styles with standard quotes
-    text = text.replace(""", "'").replace(""", "'")
-    text = text.replace('"', '"').replace('"', '"')
+    # Decode &amp; HTML entity
     text = text.replace("&amp;", "&")
 
     # Normalize whitespace
@@ -171,13 +169,18 @@ async def verify() -> bool:
             extracted_data = parse_key_value_format(post_content)
             print(f"Extracted data: {extracted_data}", file=sys.stderr)
 
-            # Load expected values from label.txt
+            # Load expected values from label.txt — hard fail if missing
             label_path = Path(__file__).parent / "label.txt"
-            if label_path.exists():
-                with open(label_path, "r") as f:
-                    expected_text = f.read().strip()
-                expected_data = parse_key_value_format(expected_text)
-                print("Loaded expected values from label.txt", file=sys.stderr)
+            if not label_path.exists():
+                print(
+                    f"Error: Ground-truth file not found at {label_path}",
+                    file=sys.stderr,
+                )
+                return False
+            with open(label_path, "r") as f:
+                expected_text = f.read().strip()
+            expected_data = parse_key_value_format(expected_text)
+            print("Loaded expected values from label.txt", file=sys.stderr)
 
             # Verify all required keys are present
             required_keys = [
@@ -208,65 +211,37 @@ async def verify() -> bool:
                 )
                 return False
 
-            # Validate data format and content
+            # Compare each field against expected_data
             errors = []
+            for key in required_keys:
+                if key in expected_data and key in extracted_data:
+                    expected_val = normalize_text(expected_data[key])
+                    actual_val = normalize_text(extracted_data[key])
 
-            # Check Total_Year_Posts is a number and matches expected
-            try:
-                total_posts = int(extracted_data["Total_Year_Posts"])
-                if "expected_data" in locals() and "Total_Year_Posts" in expected_data:
-                    expected_total = int(expected_data["Total_Year_Posts"])
-                    if total_posts != expected_total:
-                        errors.append(
-                            f"Total_Year_Posts mismatch: got {total_posts}, expected {expected_total}"
-                        )
-            except ValueError:
-                errors.append(
-                    f"Total_Year_Posts must be a number, got: {extracted_data['Total_Year_Posts']}"
-                )
-
-            # If we have expected data, compare against it
-            if "expected_data" in locals():
-                # Compare each field
-                for key in required_keys:
-                    if key in expected_data and key in extracted_data:
-                        expected_val = normalize_text(expected_data[key])
-                        actual_val = normalize_text(extracted_data[key])
-
-                        # For numeric fields, compare as integers
-                        if (
-                            "Upvotes" in key
-                            or "Comments" in key
-                            or key == "Total_Year_Posts"
-                            or key == "Total_Image_Posts_5Pages"
-                        ):
-                            try:
-                                expected_int = int(expected_val)
-                                actual_int = int(actual_val)
-                                if expected_int != actual_int:
-                                    errors.append(
-                                        f"{key} mismatch: got {actual_int}, expected {expected_int}"
-                                    )
-                            except ValueError:
-                                errors.append(
-                                    f"{key} should be numeric: got '{actual_val}'"
-                                )
-                        else:
-                            # For text fields, compare normalized text
-                            if expected_val != actual_val:
-                                errors.append(
-                                    f"{key} mismatch: got '{actual_val}', expected '{expected_val}'"
-                                )
-
-            else:
-                # If no expected data, just do basic validation
-                for key in required_keys:
-                    if key not in extracted_data:
-                        errors.append(f"Missing required key: {key}")
-                    elif (
-                        not extracted_data[key] or extracted_data[key] == "[FILL_VALUE]"
+                    # For numeric fields, compare as integers
+                    if (
+                        "Upvotes" in key
+                        or "Comments" in key
+                        or key == "Total_Year_Posts"
+                        or key == "Total_Image_Posts_5Pages"
                     ):
-                        errors.append(f"{key} was not filled in")
+                        try:
+                            expected_int = int(expected_val)
+                            actual_int = int(actual_val)
+                            if expected_int != actual_int:
+                                errors.append(
+                                    f"{key} mismatch: got {actual_int}, expected {expected_int}"
+                                )
+                        except ValueError:
+                            errors.append(
+                                f"{key} should be numeric: got '{actual_val}'"
+                            )
+                    else:
+                        # For text fields, compare normalized text
+                        if expected_val != actual_val:
+                            errors.append(
+                                f"{key} mismatch: got '{actual_val}', expected '{expected_val}'"
+                            )
 
             if errors:
                 print(

--- a/tasks/playwright_webarena/standard/reddit/nba_statistics_analysis/description.md
+++ b/tasks/playwright_webarena/standard/reddit/nba_statistics_analysis/description.md
@@ -4,8 +4,7 @@ I'm conducting research on NBA player discussions in online sports communities. 
 
 1. Register a new account with username 'NBA_DataAnalyst_2024' and password 'Research#2024!'
 
-2. Navigate to the sports forum and search for posts containing 'NBA' in their titles:
-   - Collect data from the 5 NBA-related posts with the most comments
+2. Navigate to the sports forum and browse its posts to find posts whose titles contain 'NBA'. From these, collect the 5 with the most comments:
    - For each post, record: the exact post title, vote count, comment count, and the username of the person who submitted it
 
 3. Visit the user profile of 'BCLetsRide69':
@@ -16,7 +15,6 @@ I'm conducting research on NBA player discussions in online sports communities. 
    - Body text must be EXACTLY these lines without anything (keep the keys as-is, only replace the values after the colon, follow the markdown format):
 
 ```
-- Total_NBA_Posts|FILL_VALUE
 - Top1_Title|FILL_VALUE
 - Top1_Votes|FILL_VALUE
 - Top1_Comments|FILL_VALUE

--- a/tasks/playwright_webarena/standard/reddit/nba_statistics_analysis/label.txt
+++ b/tasks/playwright_webarena/standard/reddit/nba_statistics_analysis/label.txt
@@ -1,4 +1,3 @@
-- Total_NBA_Posts|20
 - Top1_Title|Hamby claims [WNBA Champ] Aces 'unprofessional' after trade
 - Top1_Votes|614
 - Top1_Comments|170
@@ -7,7 +6,7 @@
 - Top2_Votes|1266
 - Top2_Comments|145
 - Top2_Author|XXmynameisNeganXX
-- Top3_Title|[ESPN] Announced attendance at the Alamodome tonight|68,323, a new single-game NBA record, in the Spurs' first game there since Game 4 of the 2002 Western Conference Semifinals.
+- Top3_Title|[ESPN] Announced attendance at the Alamodome tonight: 68,323, a new single-game NBA record, in the Spurs' first game there since Game 4 of the 2002 Western Conference Semifinals.
 - Top3_Votes|1511
 - Top3_Comments|101
 - Top3_Author|dragon8811

--- a/tasks/playwright_webarena/standard/reddit/nba_statistics_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/nba_statistics_analysis/verify.py
@@ -53,9 +53,8 @@ def normalize_text(text):
     if not isinstance(text, str):
         return str(text)
 
-    # Normalize curly apostrophes to ASCII (use unicode escapes so source-edit tools don't mangle them)
-    text = text.replace("\u2019", "'")  # RIGHT SINGLE QUOTATION MARK (')
-    text = text.replace("\u2018", "'")  # LEFT SINGLE QUOTATION MARK (')
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
 
     # Normalize whitespace
     text = " ".join(text.split())

--- a/tasks/playwright_webarena/standard/reddit/nba_statistics_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/nba_statistics_analysis/verify.py
@@ -23,11 +23,13 @@ def parse_key_value_format(text):
     lines = text.strip().split('\n')
     for line in lines:
         line = line.strip()
-        if not line or line.startswith('#'):
+        if not line:
             continue
-            
+
         # Remove bullet point if present
         if line.startswith('- '):
+            line = line[2:]
+        elif line.startswith('* '):
             line = line[2:]
         elif line.startswith('• '):
             line = line[2:]
@@ -51,10 +53,7 @@ def normalize_text(text):
     if not isinstance(text, str):
         return str(text)
 
-    # Replace various quote styles with standard quotes
-    text = text.replace(""", "'").replace(""", "'")
-    text = text.replace('"', '"').replace('"', '"')
-    # Also normalize apostrophes - use unicode escapes to be safe
+    # Normalize curly apostrophes to ASCII (use unicode escapes so source-edit tools don't mangle them)
     text = text.replace("\u2019", "'")  # RIGHT SINGLE QUOTATION MARK (')
     text = text.replace("\u2018", "'")  # LEFT SINGLE QUOTATION MARK (')
 
@@ -138,22 +137,22 @@ async def verify() -> bool:
                 ".post-body",
                 ".RichText",
                 '[class*="RichText"]',
-                'div:has(> p:has-text("Total_NBA_Posts"))',
-                'div:has-text("Total_NBA_Posts"):has-text("Most_Popular_NBA_Author")',
+                'div:has(> p:has-text("Top1_Title"))',
+                'div:has-text("Top1_Title"):has-text("BCLetsRide69_Total_Posts")',
             ]
 
             for selector in selectors:
                 content_element = page.locator(selector)
                 if await content_element.count():
                     post_content = await content_element.first.inner_text()
-                    if "Total_NBA_Posts" in post_content:
+                    if "Top1_Title" in post_content:
                         print(
                             f"Found submission content using selector: {selector}",
                             file=sys.stderr,
                         )
                         break
 
-            if not post_content or "Total_NBA_Posts" not in post_content:
+            if not post_content or "Top1_Title" not in post_content:
                 print(
                     "Error: Could not find submission body with required format",
                     file=sys.stderr,
@@ -167,17 +166,21 @@ async def verify() -> bool:
             extracted_data = parse_key_value_format(post_content)
             print(f"Extracted data: {extracted_data}", file=sys.stderr)
 
-            # Load expected values from label.txt
+            # Load expected values from label.txt — hard fail if missing
             label_path = Path(__file__).parent / "label.txt"
-            if label_path.exists():
-                with open(label_path, "r") as f:
-                    expected_text = f.read().strip()
-                expected_data = parse_key_value_format(expected_text)
-                print("Loaded expected values from label.txt", file=sys.stderr)
+            if not label_path.exists():
+                print(
+                    f"Error: Ground-truth file not found at {label_path}",
+                    file=sys.stderr,
+                )
+                return False
+            with open(label_path, "r") as f:
+                expected_text = f.read().strip()
+            expected_data = parse_key_value_format(expected_text)
+            print("Loaded expected values from label.txt", file=sys.stderr)
 
             # Verify all required keys are present
             required_keys = [
-                "Total_NBA_Posts",
                 "Top1_Title",
                 "Top1_Votes",
                 "Top1_Comments",
@@ -213,69 +216,36 @@ async def verify() -> bool:
                 )
                 return False
 
-            # Validate data format and content
+            # Compare each field against expected_data
             errors = []
+            for key in required_keys:
+                if key in expected_data and key in extracted_data:
+                    expected_val = normalize_text(expected_data[key])
+                    actual_val = normalize_text(extracted_data[key])
 
-            # Check Total_NBA_Posts is a number and matches expected
-            try:
-                total_posts = int(extracted_data["Total_NBA_Posts"])
-                if "expected_data" in locals() and "Total_NBA_Posts" in expected_data:
-                    expected_total = int(expected_data["Total_NBA_Posts"])
-                    if total_posts != expected_total:
-                        errors.append(
-                            f"Total_NBA_Posts mismatch: got {total_posts}, expected {expected_total}"
-                        )
-                elif (
-                    total_posts < 5
-                ):  # Should be at least 5 since we're collecting top 5
-                    errors.append(f"Total_NBA_Posts seems too low: {total_posts}")
-            except ValueError:
-                errors.append(
-                    f"Total_NBA_Posts must be a number, got: {extracted_data['Total_NBA_Posts']}"
-                )
-
-            # If we have expected data, compare against it
-            if "expected_data" in locals():
-                # Compare each field
-                for key in required_keys:
-                    if key in expected_data and key in extracted_data:
-                        expected_val = normalize_text(expected_data[key])
-                        actual_val = normalize_text(extracted_data[key])
-
-                        # For numeric fields, compare as integers
-                        if (
-                            "Votes" in key
-                            or "Comments" in key
-                            or key == "Total_NBA_Posts"
-                            or key == "BCLetsRide69_Total_Posts"
-                        ):
-                            try:
-                                expected_int = int(expected_val)
-                                actual_int = int(actual_val)
-                                if expected_int != actual_int:
-                                    errors.append(
-                                        f"{key} mismatch: got {actual_int}, expected {expected_int}"
-                                    )
-                            except ValueError:
-                                errors.append(
-                                    f"{key} should be numeric: got '{actual_val}'"
-                                )
-                        else:
-                            # For text fields, compare normalized text
-                            if expected_val != actual_val:
-                                errors.append(
-                                    f"{key} mismatch: got '{actual_val}', expected '{expected_val}'"
-                                )
-
-            else:
-                # If no expected data, just do basic validation
-                for key in required_keys:
-                    if key not in extracted_data:
-                        errors.append(f"Missing required key: {key}")
-                    elif (
-                        not extracted_data[key] or extracted_data[key] == "[FILL_VALUE]"
+                    # For numeric fields, compare as integers
+                    if (
+                        "Votes" in key
+                        or "Comments" in key
+                        or key == "BCLetsRide69_Total_Posts"
                     ):
-                        errors.append(f"{key} was not filled in")
+                        try:
+                            expected_int = int(expected_val)
+                            actual_int = int(actual_val)
+                            if expected_int != actual_int:
+                                errors.append(
+                                    f"{key} mismatch: got {actual_int}, expected {expected_int}"
+                                )
+                        except ValueError:
+                            errors.append(
+                                f"{key} should be numeric: got '{actual_val}'"
+                            )
+                    else:
+                        # For text fields, compare normalized text
+                        if expected_val != actual_val:
+                            errors.append(
+                                f"{key} mismatch: got '{actual_val}', expected '{expected_val}'"
+                            )
 
             if errors:
                 print(
@@ -291,9 +261,6 @@ async def verify() -> bool:
             print("- Account NBA_DataAnalyst_2024 verified")
             print(
                 "- Submission 'Statistical Analysis: NBA Content Engagement on This Forum' found"
-            )
-            print(
-                f"- Total NBA-related posts analyzed: {extracted_data['Total_NBA_Posts']}"
             )
             print("- Top 5 posts identified and documented")
             print(

--- a/tasks/playwright_webarena/standard/reddit/routine_tracker_forum/verify.py
+++ b/tasks/playwright_webarena/standard/reddit/routine_tracker_forum/verify.py
@@ -11,6 +11,22 @@ from playwright.async_api import (
 BASE_URL = os.getenv("WEBARENA_BASE_URL", "http://localhost:9999").rstrip("/")
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 async def verify() -> bool:
     """
     Verifies that the daily routine tracking setup has been completed correctly on the forum.
@@ -77,7 +93,7 @@ async def verify() -> bool:
             # Check if the content exists in the page
             content_found = False
             article_content = await page.locator("article").text_content()
-            if article_content and expected_content in article_content:
+            if article_content and normalize_text(expected_content) in normalize_text(article_content):
                 content_found = True
 
             if not content_found:

--- a/tasks/playwright_webarena/standard/shopping/advanced_product_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/advanced_product_analysis/verify.py
@@ -40,6 +40,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>xxx</answer> format from the agent's output.
@@ -66,7 +82,7 @@ def parse_answer_format(text):
     for line in lines:
         if "|" in line:
             key, value = line.split("|", 1)
-            result[key.strip()] = value.strip()
+            result[key.strip()] = normalize_text(value.strip())
 
     return result
 
@@ -84,7 +100,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping/advanced_product_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/advanced_product_analysis/verify.py
@@ -120,20 +120,13 @@ def compare_answers(model_answer, expected_answer):
                 )
 
         elif key == "CartTotal":
-            # For price fields, only support $XX.XX format
-            # Check if model value has correct format
-            if not model_value.startswith("$"):
+            # Compare amount only — strip $ and , so format variations don't fail a correct value
+            expected_clean = expected_value.replace("$", "").replace(",", "")
+            model_clean = model_value.replace("$", "").replace(",", "")
+            if expected_clean != model_clean:
                 mismatches.append(
-                    f"{key}: incorrect format - expected '$XX.XX' format, got '{model_value}'"
+                    f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
-            else:
-                # Normalize and compare values
-                expected_clean = expected_value.replace("$", "").replace(",", "")
-                model_clean = model_value.replace("$", "").replace(",", "")
-                if expected_clean != model_clean:
-                    mismatches.append(
-                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                    )
 
         elif key == "ReviewCount":
             # Check review count matches
@@ -143,8 +136,8 @@ def compare_answers(model_answer, expected_answer):
                 )
 
         elif key == "LatestReviewer":
-            # Check reviewer name (allow partial match for names)
-            if expected_value.lower() not in model_value.lower() and model_value.lower() not in expected_value.lower():
+            # Case-insensitive exact match
+            if expected_value.lower() != model_value.lower():
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"
                 )

--- a/tasks/playwright_webarena/standard/shopping/advanced_product_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/advanced_product_analysis/verify.py
@@ -26,6 +26,7 @@ def get_model_response():
             if (
                 message.get("role") == "assistant"
                 and message.get("status") == "completed"
+                and message.get("type") == "message"
             ):
                 content = message.get("content", [])
                 for item in content:

--- a/tasks/playwright_webarena/standard/shopping/advanced_product_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/advanced_product_analysis/verify.py
@@ -12,7 +12,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None

--- a/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/description.md
+++ b/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/description.md
@@ -2,7 +2,7 @@
 
 **Task Requirements:**
 
-1. In Video Games category, count products with customer rating 70% or higher in the first 2 pages
+1. In Video Games category, count products with customer rating 70% or higher in the first 2 pages (products without any rating do not count)
 
 2. Sort products by price (ascending) and identify the cheapest product that has customer reviews
 

--- a/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/label.txt
+++ b/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/label.txt
@@ -1,4 +1,4 @@
-Products70Plus|7
+Products70Plus|6
 CheapestReviewedSKU|B014HDAUAA
 CheapestReviewedPrice|$0.99
 ComparisonCount|2

--- a/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/verify.py
@@ -40,6 +40,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -66,7 +82,7 @@ def parse_answer_format(text):
     for line in lines:
         if "|" in line:
             key, value = line.split("|", 1)
-            result[key.strip()] = value.strip()
+            result[key.strip()] = normalize_text(value.strip())
 
     return result
 
@@ -84,7 +100,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/verify.py
@@ -107,42 +107,30 @@ def compare_answers(model_answer, expected_answer):
 
         # Special handling for different types of values
         if key in ["CheapestReviewedPrice", "N64Subtotal"]:
-            # For price fields, only support $XX.XX format
-            # Check if model value has correct format
-            if not model_value.startswith("$"):
+            # Compare amount only — strip $ and , so format variations don't fail a correct value
+            expected_clean = expected_value.replace("$", "").replace(",", "")
+            model_clean = model_value.replace("$", "").replace(",", "")
+            if expected_clean != model_clean:
                 mismatches.append(
-                    f"{key}: incorrect format - expected '$XX.XX' format, got '{model_value}'"
+                    f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
-            else:
-                # Normalize and compare values
-                expected_clean = expected_value.replace("$", "").replace(",", "")
-                model_clean = model_value.replace("$", "").replace(",", "")
-                if expected_clean != model_clean:
-                    mismatches.append(
-                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                    )
 
-        elif key == "CheckoutEmail":
-            # Email should match exactly (case-insensitive)
+        elif key in ["CheckoutEmail", "ShippingState"]:
+            # Case-insensitive exact match
             if model_value.lower() != expected_value.lower():
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
 
-        elif key == "Products70Plus":
-            # For count fields, allow some flexibility (products might change)
-            # But still check if it's a reasonable number
+        elif key in ["Products70Plus", "ComparisonCount", "ShippingMethods"]:
             try:
-                model_count = int(model_value)
-                expected_count = int(expected_value)
-                # Allow up to 2 products difference (in case of dynamic content)
-                if abs(model_count - expected_count) > 2:
+                if int(model_value) != int(expected_value):
                     mismatches.append(
-                        f"{key}: expected around '{expected_value}', got '{model_value}'"
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
                     )
             except ValueError:
                 mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                    f"{key} should be numeric: got '{model_value}'"
                 )
 
         else:

--- a/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/gaming_accessories_analysis/verify.py
@@ -12,7 +12,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None

--- a/tasks/playwright_webarena/standard/shopping/health_routine_optimization/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/health_routine_optimization/verify.py
@@ -115,20 +115,26 @@ def compare_answers(model_answer, expected_answer):
 
         # Special handling for different types of values
         if key in ["Battery1Price", "Battery2Price", "InitialSubtotal", "FinalSubtotal"]:
-            # For price fields, only support $XX.XX format
-            # Check if model value has correct format
-            if not model_value.startswith("$"):
+            # Compare amount only — strip $ and , so format variations don't fail a correct value
+            expected_clean = expected_value.replace("$", "").replace(",", "")
+            model_clean = model_value.replace("$", "").replace(",", "")
+            if expected_clean != model_clean:
                 mismatches.append(
-                    f"{key}: incorrect format - expected '$XX.XX' format, got '{model_value}'"
+                    f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
-            else:
-                # Normalize and compare values
-                expected_clean = expected_value.replace("$", "").replace(",", "")
-                model_clean = model_value.replace("$", "").replace(",", "")
-                if expected_clean != model_clean:
+
+        elif key in ["AdvancedSearchResults", "ComparisonCount", "TeaReviews",
+                     "CartUniqueProducts", "CartTotalQuantity", "TeaRating"]:
+            # Strip % so "95" and "95%" both compare as 95
+            try:
+                if int(model_value.replace("%", "")) != int(expected_value.replace("%", "")):
                     mismatches.append(
                         f"{key}: expected '{expected_value}', got '{model_value}'"
                     )
+            except ValueError:
+                mismatches.append(
+                    f"{key} should be numeric: got '{model_value}'"
+                )
 
         else:
             # Exact match for other fields

--- a/tasks/playwright_webarena/standard/shopping/health_routine_optimization/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/health_routine_optimization/verify.py
@@ -13,7 +13,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None

--- a/tasks/playwright_webarena/standard/shopping/health_routine_optimization/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/health_routine_optimization/verify.py
@@ -40,6 +40,22 @@ def get_model_response():
         print(f"Error reading messages file: {str(e)}", file=sys.stderr)
         return None
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -66,7 +82,7 @@ def parse_answer_format(text):
     for line in lines:
         if "|" in line:
             key, value = line.split("|", 1)
-            result[key.strip()] = value.strip()
+            result[key.strip()] = normalize_text(value.strip())
 
     return result
 
@@ -93,7 +109,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping/holiday_baking_competition/description.md
+++ b/tasks/playwright_webarena/standard/shopping/holiday_baking_competition/description.md
@@ -20,7 +20,7 @@
 
 4. In cart:
    - Update cookie quantity from 2 to 5
-   - Record cart subtotal and total items count
+   - Record cart subtotal and total items count (sum of all product quantities, not the number of distinct products)
 
 5. Search 'gingerbread', go to page 2:
    - Find third product on page 2

--- a/tasks/playwright_webarena/standard/shopping/holiday_baking_competition/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/holiday_baking_competition/verify.py
@@ -114,35 +114,29 @@ def compare_answers(model_answer, expected_answer):
                 )
                 
         elif key in ["CartSubtotalAfterUpdate"]:
-            # For price fields, only support $XX.XX format
-            # Check if model value has correct format
-            if not model_value.startswith("$"):
-                mismatches.append(
-                    f"{key}: incorrect format - expected '$XX.XX' format, got '{model_value}'"
-                )
-            else:
-                # Normalize and compare values
-                expected_clean = expected_value.replace("$", "").replace(",", "")
-                model_clean = model_value.replace("$", "").replace(",", "")
-                # Allow some tolerance for price calculations (within $0.01)
-                try:
-                    expected_float = float(expected_clean)
-                    model_float = float(model_clean)
-                    if abs(expected_float - model_float) > 0.01:
-                        mismatches.append(
-                            f"{key}: expected '{expected_value}', got '{model_value}'"
-                        )
-                except ValueError:
-                    if expected_value != model_value:
-                        mismatches.append(
-                            f"{key}: expected '{expected_value}', got '{model_value}'"
-                        )
+            # Strip $ and , then compare as floats (exact equality — no tolerance)
+            expected_clean = expected_value.replace("$", "").replace(",", "")
+            model_clean = model_value.replace("$", "").replace(",", "")
+            try:
+                if float(expected_clean) != float(model_clean):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
+                if expected_value != model_value:
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
                     
         elif key in ["TotalCartItems"]:
-            # Should be a number
-            if model_value != expected_value:
+            try:
+                if int(model_value) != int(expected_value):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
                 mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                    f"{key} should be numeric: got '{model_value}'"
                 )
                 
         elif key in ["HighestRatedCookieSKURating", "CheapestChocolatePriceReviews", "Page2ThirdProductSKUPrice"]:
@@ -153,49 +147,49 @@ def compare_answers(model_answer, expected_answer):
                 if len(expected_parts) == 2 and len(model_parts) == 2:
                     # For price fields, normalize the price part
                     if key == "CheapestChocolatePriceReviews":
-                        # Check if price part has correct format ($XX.XX)
-                        if not model_parts[0].startswith("$"):
-                            mismatches.append(
-                                f"{key}: incorrect format - price part should start with '$', got '{model_value}'"
-                            )
-                        else:
-                            expected_price = expected_parts[0].replace("$", "").replace(",", "")
-                            model_price = model_parts[0].replace("$", "").replace(",", "")
-                            try:
-                                if abs(float(expected_price) - float(model_price)) > 0.01 or expected_parts[1] != model_parts[1]:
-                                    mismatches.append(
-                                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                                    )
-                            except ValueError:
-                                if expected_value != model_value:
-                                    mismatches.append(
-                                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                                    )
+                        # Price as float (exact, no tolerance), reviews as int
+                        expected_price = expected_parts[0].replace("$", "").replace(",", "")
+                        model_price = model_parts[0].replace("$", "").replace(",", "")
+                        try:
+                            if (float(expected_price) != float(model_price)
+                                    or int(expected_parts[1]) != int(model_parts[1])):
+                                mismatches.append(
+                                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                                )
+                        except ValueError:
+                            if expected_value != model_value:
+                                mismatches.append(
+                                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                                )
                     elif key == "Page2ThirdProductSKUPrice":
-                        # Check if price part has correct format ($XX.XX)
-                        if not model_parts[1].startswith("$"):
-                            mismatches.append(
-                                f"{key}: incorrect format - price part should start with '$', got '{model_value}'"
-                            )
-                        else:
-                            expected_price = expected_parts[1].replace("$", "").replace(",", "")
-                            model_price = model_parts[1].replace("$", "").replace(",", "")
-                            try:
-                                if expected_parts[0] != model_parts[0] or abs(float(expected_price) - float(model_price)) > 0.01:
-                                    mismatches.append(
-                                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                                    )
-                            except ValueError:
-                                if expected_value != model_value:
-                                    mismatches.append(
-                                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                                    )
+                        # SKU exact (case-insensitive), price as float (exact, no tolerance)
+                        expected_price = expected_parts[1].replace("$", "").replace(",", "")
+                        model_price = model_parts[1].replace("$", "").replace(",", "")
+                        try:
+                            if (expected_parts[0].upper() != model_parts[0].upper()
+                                    or float(expected_price) != float(model_price)):
+                                mismatches.append(
+                                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                                )
+                        except ValueError:
+                            if expected_value != model_value:
+                                mismatches.append(
+                                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                                )
                     else:
-                        # For rating fields, exact match
-                        if expected_value != model_value:
-                            mismatches.append(
-                                f"{key}: expected '{expected_value}', got '{model_value}'"
-                            )
+                        # HighestRatedCookieSKURating: SKU exact (case-insensitive) + rating as int (strip %)
+                        try:
+                            if (expected_parts[0].upper() != model_parts[0].upper()
+                                    or int(expected_parts[1].replace("%", ""))
+                                       != int(model_parts[1].replace("%", ""))):
+                                mismatches.append(
+                                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                                )
+                        except ValueError:
+                            if expected_value != model_value:
+                                mismatches.append(
+                                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                                )
                 else:
                     mismatches.append(
                         f"{key}: expected '{expected_value}', got '{model_value}'"

--- a/tasks/playwright_webarena/standard/shopping/holiday_baking_competition/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/holiday_baking_competition/verify.py
@@ -40,6 +40,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -66,7 +82,7 @@ def parse_answer_format(text):
     for line in lines:
         if "|" in line:
             key, value = line.split("|", 1)
-            result[key.strip()] = value.strip()
+            result[key.strip()] = normalize_text(value.strip())
 
     return result
 
@@ -84,7 +100,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping/holiday_baking_competition/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/holiday_baking_competition/verify.py
@@ -12,7 +12,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None

--- a/tasks/playwright_webarena/standard/shopping/multi_category_budget_analysis/description.md
+++ b/tasks/playwright_webarena/standard/shopping/multi_category_budget_analysis/description.md
@@ -1,4 +1,4 @@
-Complete the following tasks on One Stop Market (http://localhost:7770):
+Complete the following tasks on One Stop Market:
 
 **Task Requirements:**
 
@@ -6,8 +6,8 @@ Complete the following tasks on One Stop Market (http://localhost:7770):
    - Record price and SKU of first 3 products
 
 2. Search for 'tabletop' with price range $100.00-$200.00:
-   - Find the cheapest tabletop that has the highest review rating with at least 3 reviews.
    - Record search results count
+   - Among tabletops with at least 3 reviews, find the one with the highest rating % (if tied, choose the cheapest)
    - Record price of required tabletop
 
 3. In "Computers & Accessories" subcategory with price filter $0.00-$9,999.99:
@@ -27,7 +27,7 @@ Complete the following tasks on One Stop Market (http://localhost:7770):
 
 6. Calculate:
    - Sum of 3 chocolate product prices
-   - Price difference: cheapest tabletop minus cheapest computer accessory
+   - Price difference: selected tabletop (from step 2) minus cheapest computer accessory (from step 3)
    - Whether sum of 3 comparison items < $60
 
 **Output Format:**

--- a/tasks/playwright_webarena/standard/shopping/multi_category_budget_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/multi_category_budget_analysis/verify.py
@@ -120,11 +120,16 @@ def compare_answers(model_answer, expected_answer):
                     if len(exp_parts) != 2 or len(mod_parts) != 2:
                         mismatches.append(f"{key}: product {i+1} format error - expected 'price:SKU'")
                     else:
-                        # Check price format (should start with $)
-                        if not mod_parts[0].startswith("$"):
-                            mismatches.append(f"{key}: product {i+1} price format error - expected '$XX.XX' format, got '{mod_parts[0]}'")
-                        elif exp_parts[0] != mod_parts[0] or exp_parts[1] != mod_parts[1]:
-                            mismatches.append(f"{key}: product {i+1} mismatch - expected '{exp}', got '{mod}'")
+                        # Price as float (exact, no tolerance), SKU case-insensitive
+                        exp_price = exp_parts[0].replace("$", "").replace(",", "")
+                        mod_price = mod_parts[0].replace("$", "").replace(",", "")
+                        try:
+                            if (float(exp_price) != float(mod_price)
+                                    or exp_parts[1].upper() != mod_parts[1].upper()):
+                                mismatches.append(f"{key}: product {i+1} mismatch - expected '{exp}', got '{mod}'")
+                        except ValueError:
+                            if exp != mod:
+                                mismatches.append(f"{key}: product {i+1} mismatch - expected '{exp}', got '{mod}'")
 
         elif key == "tabletop_product":
             # Parse and compare tabletop product with price:SKU format
@@ -133,11 +138,16 @@ def compare_answers(model_answer, expected_answer):
             if len(exp_parts) != 2 or len(mod_parts) != 2:
                 mismatches.append(f"{key}: format error - expected 'price:SKU', got '{model_value}'")
             else:
-                # Check price format (should start with $)
-                if not mod_parts[0].startswith("$"):
-                    mismatches.append(f"{key}: price format error - expected '$XX.XX' format, got '{mod_parts[0]}'")
-                elif exp_parts[0] != mod_parts[0] or exp_parts[1] != mod_parts[1]:
-                    mismatches.append(f"{key}: mismatch - expected '{expected_value}', got '{model_value}'")
+                # Price as float (exact, no tolerance), SKU case-insensitive
+                exp_price = exp_parts[0].replace("$", "").replace(",", "")
+                mod_price = mod_parts[0].replace("$", "").replace(",", "")
+                try:
+                    if (float(exp_price) != float(mod_price)
+                            or exp_parts[1].upper() != mod_parts[1].upper()):
+                        mismatches.append(f"{key}: mismatch - expected '{expected_value}', got '{model_value}'")
+                except ValueError:
+                    if expected_value != model_value:
+                        mismatches.append(f"{key}: mismatch - expected '{expected_value}', got '{model_value}'")
         
         elif key == "tabletop_reviews":
             # Parse and compare tabletop reviews with NumberOfReviews:Rating format
@@ -146,22 +156,26 @@ def compare_answers(model_answer, expected_answer):
             if len(exp_parts) != 2 or len(mod_parts) != 2:
                 mismatches.append(f"{key}: format error - expected 'NumberOfReviews:Rating', got '{model_value}'")
             else:
-                # Check if both parts match
-                if exp_parts[0] != mod_parts[0] or exp_parts[1] != mod_parts[1]:
-                    mismatches.append(f"{key}: mismatch - expected '{expected_value}', got '{model_value}'")
+                # Reviews as int, rating as int (strip %)
+                try:
+                    if (int(exp_parts[0]) != int(mod_parts[0])
+                            or int(exp_parts[1].replace("%", "")) != int(mod_parts[1].replace("%", ""))):
+                        mismatches.append(f"{key}: mismatch - expected '{expected_value}', got '{model_value}'")
+                except ValueError:
+                    if expected_value != model_value:
+                        mismatches.append(f"{key}: mismatch - expected '{expected_value}', got '{model_value}'")
 
         elif key in ["chocolate_sum", "price_difference", "cart_subtotal", "cheapest_computer_accessory"]:
-            # For price fields, only support $XX.XX format
-            # Check if model value has correct format
-            if not model_value.startswith("$"):
-                mismatches.append(
-                    f"{key}: incorrect format - expected '$XX.XX' format, got '{model_value}'"
-                )
-            else:
-                # Normalize and compare values
-                expected_clean = expected_value.replace("$", "").replace(",", "")
-                model_clean = model_value.replace("$", "").replace(",", "")
-                if expected_clean != model_clean:
+            # Strip $ and , then compare as floats (exact equality — no tolerance)
+            expected_clean = expected_value.replace("$", "").replace(",", "")
+            model_clean = model_value.replace("$", "").replace(",", "")
+            try:
+                if float(expected_clean) != float(model_clean):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
+                if expected_value != model_value:
                     mismatches.append(
                         f"{key}: expected '{expected_value}', got '{model_value}'"
                     )
@@ -172,10 +186,14 @@ def compare_answers(model_answer, expected_answer):
                 mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
 
         elif key in ["tabletop_search_count", "comparison_count", "cart_item_count"]:
-            # Numeric fields - exact match
-            if model_value != expected_value:
+            try:
+                if int(model_value) != int(expected_value):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
                 mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                    f"{key} should be numeric: got '{model_value}'"
                 )
 
         else:

--- a/tasks/playwright_webarena/standard/shopping/multi_category_budget_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/multi_category_budget_analysis/verify.py
@@ -40,6 +40,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -66,7 +82,7 @@ def parse_answer_format(text):
     for line in lines:
         if "|" in line:
             key, value = line.split("|", 1)
-            result[key.strip()] = value.strip()
+            result[key.strip()] = normalize_text(value.strip())
 
     return result
 
@@ -84,7 +100,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping/multi_category_budget_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/multi_category_budget_analysis/verify.py
@@ -12,7 +12,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None

--- a/tasks/playwright_webarena/standard/shopping/printer_keyboard_search/description.md
+++ b/tasks/playwright_webarena/standard/shopping/printer_keyboard_search/description.md
@@ -1,12 +1,13 @@
 
 
 1. Search for a `printer capable of reducing blue light` that:
-   - Is pink or purple (must be stated in product details, not from image)
+   - Price between $240.00-$260.00
+   - Is pink or purple
    - Manufactured in Asia
    Record SKU ID and price
 
 2. Find a keyboard with:
-   - Bluetooth mode (must be stated either stated in details or title)
+   - Bluetooth mode
    - Price between $50.00-$100.00
    - Highest review rating among matching products
    Record SKU ID, price, number of reviews, and review rating

--- a/tasks/playwright_webarena/standard/shopping/printer_keyboard_search/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/printer_keyboard_search/verify.py
@@ -40,6 +40,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -66,7 +82,7 @@ def parse_answer_format(text):
     for line in lines:
         if "|" in line:
             key, value = line.split("|", 1)
-            result[key.strip()] = value.strip()
+            result[key.strip()] = normalize_text(value.strip())
 
     return result
 
@@ -84,7 +100,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping/printer_keyboard_search/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/printer_keyboard_search/verify.py
@@ -107,17 +107,16 @@ def compare_answers(model_answer, expected_answer):
 
         # Special handling for different types of values
         if key in ["PrinterPrice", "KeyboardPrice"]:
-            # For price fields, only support $XX.XX format
-            # Check if model value has correct format
-            if not model_value.startswith("$"):
-                mismatches.append(
-                    f"{key}: incorrect format - expected '$XX.XX' format, got '{model_value}'"
-                )
-            else:
-                # Normalize and compare values
-                expected_clean = expected_value.replace("$", "").replace(",", "")
-                model_clean = model_value.replace("$", "").replace(",", "")
-                if expected_clean != model_clean:
+            # Strip $ and , then compare as floats (exact equality — no tolerance)
+            expected_clean = expected_value.replace("$", "").replace(",", "")
+            model_clean = model_value.replace("$", "").replace(",", "")
+            try:
+                if float(expected_clean) != float(model_clean):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
+                if expected_value != model_value:
                     mismatches.append(
                         f"{key}: expected '{expected_value}', got '{model_value}'"
                     )
@@ -130,17 +129,26 @@ def compare_answers(model_answer, expected_answer):
                 )
 
         elif key == "KeyboardReviews":
-            # Number of reviews should match exactly
-            if model_value != expected_value:
+            try:
+                if int(model_value) != int(expected_value):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
                 mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                    f"{key} should be numeric: got '{model_value}'"
                 )
 
         elif key == "KeyboardRating":
-            # Rating should match exactly (including % sign)
-            if model_value != expected_value:
+            # Strip % and compare as int
+            try:
+                if int(model_value.replace("%", "")) != int(expected_value.replace("%", "")):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
                 mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                    f"{key} should be numeric: got '{model_value}'"
                 )
 
         else:

--- a/tasks/playwright_webarena/standard/shopping/printer_keyboard_search/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/printer_keyboard_search/verify.py
@@ -12,7 +12,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None

--- a/tasks/playwright_webarena/standard/shopping/running_shoes_purchase/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/running_shoes_purchase/verify.py
@@ -107,30 +107,19 @@ def compare_answers(model_answer, expected_answer):
 
         # Special handling for different types of values
         if key in ["Price", "Subtotal"]:
-            # For price fields, only support $XX.XX format
-            # Check if model value has correct format
-            if not model_value.startswith("$"):
-                mismatches.append(
-                    f"{key}: incorrect format - expected '$XX.XX' format, got '{model_value}'"
-                )
-            else:
-                # Normalize and compare values
-                expected_clean = expected_value.replace("$", "").replace(",", "")
-                model_clean = model_value.replace("$", "").replace(",", "")
-                
-                # Allow small tolerance for price calculations (within $0.01)
-                try:
-                    expected_float = float(expected_clean)
-                    model_float = float(model_clean)
-                    if abs(expected_float - model_float) > 0.01:
-                        mismatches.append(
-                            f"{key}: expected '{expected_value}', got '{model_value}'"
-                        )
-                except ValueError:
-                    if expected_clean != model_clean:
-                        mismatches.append(
-                            f"{key}: expected '{expected_value}', got '{model_value}'"
-                        )
+            # Strip $ and , then compare as floats (exact equality — no tolerance)
+            expected_clean = expected_value.replace("$", "").replace(",", "")
+            model_clean = model_value.replace("$", "").replace(",", "")
+            try:
+                if float(expected_clean) != float(model_clean):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
+                if expected_value != model_value:
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
 
         elif key == "SKUID":
             # SKU should match exactly (case-insensitive)
@@ -140,17 +129,26 @@ def compare_answers(model_answer, expected_answer):
                 )
 
         elif key == "NumberOfReviews":
-            # Number of reviews should match exactly
-            if model_value != expected_value:
+            try:
+                if int(model_value) != int(expected_value):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
                 mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                    f"{key} should be numeric: got '{model_value}'"
                 )
 
         elif key == "ReviewRating":
-            # Rating should match exactly (including % sign)
-            if model_value != expected_value:
+            # Strip % and compare as int
+            try:
+                if int(model_value.replace("%", "")) != int(expected_value.replace("%", "")):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
                 mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                    f"{key} should be numeric: got '{model_value}'"
                 )
 
         else:

--- a/tasks/playwright_webarena/standard/shopping/running_shoes_purchase/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/running_shoes_purchase/verify.py
@@ -40,6 +40,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -66,7 +82,7 @@ def parse_answer_format(text):
     for line in lines:
         if "|" in line:
             key, value = line.split("|", 1)
-            result[key.strip()] = value.strip()
+            result[key.strip()] = normalize_text(value.strip())
 
     return result
 
@@ -84,7 +100,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping/running_shoes_purchase/verify.py
+++ b/tasks/playwright_webarena/standard/shopping/running_shoes_purchase/verify.py
@@ -12,7 +12,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None

--- a/tasks/playwright_webarena/standard/shopping_admin/customer_segmentation_setup/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/customer_segmentation_setup/verify.py
@@ -33,6 +33,7 @@ def get_model_response():
             if (
                 message.get("role") == "assistant"
                 and message.get("status") == "completed"
+                and message.get("type") == "message"
             ):
                 content = message.get("content", [])
                 for item in content:
@@ -111,11 +112,28 @@ def compare_answers(model_answer, expected_answer):
     for key, expected_value in expected_answer.items():
         model_value = model_answer.get(key, "")
 
-        # Exact match for all fields
-        if model_value != expected_value:
-            mismatches.append(
-                f"{key}: expected '{expected_value}', got '{model_value}'"
-            )
+        if key in ["InitialGroups", "FinalGroups", "InitialCustomers", "FinalCustomers"]:
+            try:
+                if int(model_value) != int(expected_value):
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+            except ValueError:
+                mismatches.append(
+                    f"{key} should be numeric: got '{model_value}'"
+                )
+        elif key == "LastOrderCustomer":
+            # Case-insensitive exact match
+            if model_value.lower() != expected_value.lower():
+                mismatches.append(
+                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                )
+        else:
+            # Exact match for other fields
+            if model_value != expected_value:
+                mismatches.append(
+                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                )
 
     if mismatches:
         print("\n=== Answer Comparison Mismatches ===", file=sys.stderr)
@@ -165,12 +183,10 @@ async def verify() -> bool:
                 "Warning: Could not parse answer format from model response",
                 file=sys.stderr,
             )
-            print("Will proceed with browser verification only", file=sys.stderr)
+            return False
     else:
-        print(
-            "No model response found, proceeding with browser verification",
-            file=sys.stderr,
-        )
+        print("No model response found", file=sys.stderr)
+        return False
 
     # Browser verification for actual state
     print("\n=== Starting Browser Verification ===", file=sys.stderr)
@@ -227,26 +243,19 @@ async def verify() -> bool:
                         )
                     else:
                         print(
-                            f"Warning: Premium Europe tax class is '{tax_class_text}'",
+                            f"✗ Premium Europe tax class is '{tax_class_text}', expected 'Retail Customer'",
                             file=sys.stderr,
                         )
+                        return False
+                else:
+                    print(
+                        "✗ Could not locate 'Premium Europe' row to verify tax class",
+                        file=sys.stderr,
+                    )
+                    return False
             else:
                 print("✗ 'Premium Europe' customer group not found", file=sys.stderr)
                 return False
-
-            # Check total groups count
-            records_found = page.locator("text=records found").first
-            if await records_found.count() > 0:
-                count_text = await records_found.inner_text()
-                print(f"Customer Groups count: {count_text}", file=sys.stderr)
-
-                # Extract number
-                import re
-
-                match = re.search(r"(\d+)\s+records found", count_text)
-                if match:
-                    groups_count = int(match.group(1))
-                    print(f"✓ Customer groups count is {groups_count}", file=sys.stderr)
 
             # 2. Verify Customer
             print("\nVerifying Customer Isabella Romano...", file=sys.stderr)
@@ -255,35 +264,6 @@ async def verify() -> bool:
                 wait_until="networkidle",
             )
             await page.wait_for_timeout(3000)  # Wait for grid to load
-
-            # Check total customers count
-            customer_records = page.locator("text=records found").first
-            if await customer_records.count() > 0:
-                count_text = await customer_records.inner_text()
-                print(f"Customers count: {count_text}", file=sys.stderr)
-
-                # Extract number
-                match = re.search(r"(\d+)\s+records found", count_text)
-                if match:
-                    customers_count = int(match.group(1))
-                    print(
-                        f"✓ Total customers count is {customers_count}", file=sys.stderr
-                    )
-
-                    # Verify against expected answer if available
-                    if expected_answer and "FinalCustomers" in expected_answer:
-                        expected_final = int(expected_answer["FinalCustomers"])
-                        if customers_count == expected_final:
-                            print(
-                                f"✓ Customer count matches expected: {customers_count}",
-                                file=sys.stderr,
-                            )
-                        else:
-                            print(
-                                f"✗ Customer count mismatch: Expected {expected_final} customers, found {customers_count}",
-                                file=sys.stderr,
-                            )
-                            return False
 
             # Wait for the customer grid to load properly
             await page.wait_for_timeout(5000)
@@ -325,17 +305,9 @@ async def verify() -> bool:
                         isabella_exists = (
                             await page.locator("text=isabella.romano@premium.eu").count() > 0
                         )
-                        
-                        # Also check for "No records found" message
-                        no_records = await page.locator("text=We couldn't find any records., text=No records found").count() > 0
-                        if no_records:
-                            print(
-                                "✗ Customer 'isabella.romano@premium.eu' not found - search returned no results",
-                                file=sys.stderr,
-                            )
-                            return False
                 except Exception as e:
                     print(f"✗ Search failed: {str(e)}", file=sys.stderr)
+                    return False
             
             if isabella_exists:
                 print(
@@ -349,58 +321,6 @@ async def verify() -> bool:
                 )
                 return False
 
-            # 3. Verify Dashboard Last Orders
-            print("\nVerifying Dashboard Last Orders...", file=sys.stderr)
-            await page.goto(
-                f"{BASE_URL}/admin/dashboard/",
-                wait_until="networkidle",
-            )
-            await page.wait_for_timeout(2000)
-
-            # Check for Last Orders section
-            last_orders_exists = await page.locator("text=Last Orders").count() > 0
-            if last_orders_exists:
-                print("✓ Found 'Last Orders' section on dashboard", file=sys.stderr)
-
-                # Find the first customer in the table
-                # Look for the table after "Last Orders" heading
-                orders_table = (
-                    page.locator("text=Last Orders")
-                    .locator("..")
-                    .locator("table")
-                    .first
-                )
-                if await orders_table.count() > 0:
-                    # Get the last row in tbody
-                    last_row = orders_table.locator("tbody tr").last
-                    if await last_row.count() > 0:
-                        last_customer = await last_row.locator(
-                            "td"
-                        ).first.inner_text()
-                        print(
-                            f"✓ Last customer in Last Orders: {last_customer}",
-                            file=sys.stderr,
-                        )
-
-                        # Verify against expected answer if available
-                        if expected_answer and "LastOrderCustomer" in expected_answer:
-                            if last_customer == expected_answer["LastOrderCustomer"]:
-                                print(
-                                    f"✓ Last Order Customer matches expected: {last_customer}",
-                                    file=sys.stderr,
-                                )
-                            else:
-                                print(
-                                    f"✗ Last Order Customer mismatch: Expected '{expected_answer['LastOrderCustomer']}' but actual is '{last_customer}'",
-                                    file=sys.stderr,
-                                )
-                                return False
-            else:
-                print(
-                    "Warning: 'Last Orders' section not found on dashboard",
-                    file=sys.stderr,
-                )
-
             # Summary of verification - only print if we reach this point (all checks passed)
             print("\n=== Browser Verification Summary ===", file=sys.stderr)
             print("✓ Magento Admin login successful", file=sys.stderr)
@@ -409,8 +329,6 @@ async def verify() -> bool:
                 file=sys.stderr,
             )
             print("✓ Customer 'isabella.romano@premium.eu' found in system", file=sys.stderr)
-            print("✓ Customer counts verified", file=sys.stderr)
-            print("✓ Dashboard Last Orders section accessible", file=sys.stderr)
 
             return True
 

--- a/tasks/playwright_webarena/standard/shopping_admin/customer_segmentation_setup/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/customer_segmentation_setup/verify.py
@@ -47,6 +47,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -73,7 +89,7 @@ def parse_answer_format(text):
     for line in lines:
         if "|" in line:
             key, value = line.split("|", 1)
-            result[key.strip()] = value.strip()
+            result[key.strip()] = normalize_text(value.strip())
 
     return result
 
@@ -91,7 +107,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping_admin/customer_segmentation_setup/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/customer_segmentation_setup/verify.py
@@ -19,7 +19,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None

--- a/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/description.md
+++ b/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/description.md
@@ -5,19 +5,17 @@ Our marketing team is planning a new promotion for our bestselling fitness produ
 1. If need to login, login with username 'admin' and password 'admin1234'
 
 2. Start by checking our current bestsellers:
-   - Identify the top 3 bestselling products based on their Price	and Quantity - record their names, prices, and quantities sold
-   - Note the total Revenue amount displayed
-   - Check if any of these bestsellers appear in the Top Search Terms table - if yes, record the search term and its usage count, else output 'No:0'
+   - Identify the top 3 bestselling products based on their Price and Quantity - record their names, prices, and quantities sold
+   - Check if any of these bestsellers appear in the Top Search Terms table - if yes, record the search term and its usage count, else output 'None:0'
 
 3. Investigate these bestselling products in detail:
-   - For each of the top 3 bestsellers identified, search for them by name and record:
+   - For each of the top 3 bestsellers, open the product page linked from the Bestsellers row and record:
      - Their SKU
-     - Current inventory quantity
+     - Salable Quantity
      - Whether they are 'Enabled' or 'Disabled'
 
-4. Check if we have existing promotions for these products:
-   - Look for any active rules that might apply to fitness/yoga products
-   - Find if there's a rule offering percentage discount - record the rule name and discount percentage
+4. Check existing Cart Price Rules (Marketing → Promotions → Cart Price Rules):
+   - Find the rule that offers a percentage discount on the entire order (not tied to a specific product) - record the rule name and discount percentage
    - Count total number of active rules
 
 5. Analyze customer purchasing patterns:
@@ -27,16 +25,15 @@ Our marketing team is planning a new promotion for our bestselling fitness produ
 6. Review our top customers who might be interested:
    - Find the customer who appears in the Last Orders section of the dashboard with the highest total
    - Look up this customer in the All Customers list and record his email and customer group
-   - Count how many other customers are in the same group
+   - Count how many customers are in the same group
 
 7. Compile your findings and output them in the following exact format:
 
 ```
 <answer>
-Bestseller1|name:price:quantity:sku:inventory:status
-Bestseller2|name:price:quantity:sku:inventory:status
-Bestseller3|name:price:quantity:sku:inventory:status
-TotalRevenue|amount
+Bestseller1|name:price:quantity:sku:salable_quantity:status
+Bestseller2|name:price:quantity:sku:salable_quantity:status
+Bestseller3|name:price:quantity:sku:salable_quantity:status
 BestsellerInSearch|term:count
 PercentageDiscountRule|name:percentage
 ActiveRulesCount|count
@@ -53,13 +50,12 @@ SameGroupCustomers|count
 Bestseller1|Product Name:$XX.XX:X:XXX(SKU):X:Enabled/Disabled
 Bestseller2|Product Name:$XX.XX:X:XXX(SKU):X:Enabled/Disabled
 Bestseller3|Product Name:$XX.XX:X:XXX(SKU):X:Enabled/Disabled
-TotalRevenue|$XX.XX
 BestsellerInSearch|Term:X or None:0
 PercentageDiscountRule|Rule Name:XX%
 ActiveRulesCount|X
 TotalOrders|X
-MostRecentOrderID|X or None
-TopCustomer|Customer Name:email@example.com:Group Name
+MostRecentOrderID|X
+TopCustomer|Customer Name:<customer email>:Group Name
 SameGroupCustomers|X
 </answer>
 ```

--- a/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/label.txt
+++ b/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/label.txt
@@ -1,11 +1,10 @@
-Bestseller1|Sprite Stasis Ball 65 cm:$27.00:6:24-WG082-blue:100:Enabled
-Bestseller2|Quest Lumaflex™ Band:$19.00:6:24-UG01:100:Enabled
-Bestseller3|Sprite Yoga Strap 6 foot:$14.00:6:24-WG085:100:Enabled
-TotalRevenue|$0.00
-BestsellerInSearch|No:0
+Bestseller1|Sprite Stasis Ball 65 cm:$27.00:6:24-WG082-blue:93:Enabled
+Bestseller2|Quest Lumaflex™ Band:$19.00:6:24-UG01:93:Enabled
+Bestseller3|Sprite Yoga Strap 6 foot:$14.00:6:24-WG085:88:Enabled
+BestsellerInSearch|None:0
 PercentageDiscountRule|20% OFF Ever $200-plus purchase!*:20%
 ActiveRulesCount|4
 TotalOrders|308
 MostRecentOrderID|000000299
-TopCustomer|Sarah Miller:sarah.miller@example.com:General
+TopCustomer|Sarah Miller:helloworld@yahoo.com:General
 SameGroupCustomers|70

--- a/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/verify.py
@@ -11,7 +11,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None
@@ -22,7 +22,11 @@ def get_model_response():
         
         # Find the last assistant message
         for message in reversed(messages):
-            if message.get('role') == 'assistant' and message.get('status') == 'completed':
+            if (
+                message.get('role') == 'assistant'
+                and message.get('status') == 'completed'
+                and message.get('type') == 'message'
+            ):
                 content = message.get('content', [])
                 for item in content:
                     if item.get('type') == 'output_text':
@@ -85,6 +89,31 @@ def load_expected_answer(label_path):
         print(f"Error reading label file: {str(e)}", file=sys.stderr)
         return None
 
+def _normalize_bestseller(value):
+    """
+    Parse a Bestseller line "name:price:quantity:sku:salable_quantity:status"
+    into a normalized tuple so the three lines can be compared as a set
+    (order-independent). Returns None if the value is malformed.
+    """
+    if ':' not in value:
+        return None
+    parts = value.split(':')
+    if len(parts) != 6:
+        return None
+    name, price, qty, sku, salable, status = parts
+    try:
+        return (
+            name.strip().lower(),
+            float(price.replace('$', '').replace(',', '').strip()),
+            int(qty.strip()),
+            sku.strip().lower(),
+            float(salable.replace(',', '').strip()),
+            status.strip().lower(),
+        )
+    except ValueError:
+        return None
+
+
 def compare_answers(model_answer, expected_answer):
     """
     Compare the model's answer with the expected answer.
@@ -92,63 +121,38 @@ def compare_answers(model_answer, expected_answer):
     """
     if not model_answer or not expected_answer:
         return False
-    
-    # Check each expected key
+
+    bestseller_keys = ['Bestseller1', 'Bestseller2', 'Bestseller3']
     mismatches = []
+
+    # Bestseller1/2/3 are compared as a set — model may list the three lines
+    # in any order
+    expected_bs_raw = [expected_answer.get(k, '') for k in bestseller_keys if k in expected_answer]
+    if expected_bs_raw:
+        model_bs_raw = [model_answer.get(k, '') for k in bestseller_keys if k in model_answer]
+        expected_bs = [_normalize_bestseller(v) for v in expected_bs_raw]
+        model_bs = [_normalize_bestseller(v) for v in model_bs_raw]
+        if None in expected_bs:
+            mismatches.append(f"Bestseller (label): malformed line in label.txt: {expected_bs_raw}")
+        elif None in model_bs:
+            bad = [r for r, n in zip(model_bs_raw, model_bs) if n is None]
+            mismatches.append(f"Bestseller: malformed or non-numeric line(s): {bad}")
+        else:
+            expected_set = set(expected_bs)
+            model_set = set(model_bs)
+            missing = expected_set - model_set
+            extra = model_set - expected_set
+            if missing or extra:
+                mismatches.append(
+                    f"Bestseller set mismatch — missing: {sorted(missing)}; extra: {sorted(extra)}"
+                )
+
     for key, expected_value in expected_answer.items():
+        if key in bestseller_keys:
+            continue  # already handled above
         model_value = model_answer.get(key, '')
-        
-        # Special handling for different types of values
-        if key in ['Bestseller1', 'Bestseller2', 'Bestseller3']:
-            # Check if all parts match (name:price:quantity:sku:inventory:status)
-            if ':' in expected_value and ':' in model_value:
-                expected_parts = expected_value.split(':')
-                model_parts = model_value.split(':')
-                if len(expected_parts) == 6 and len(model_parts) == 6:
-                    # Compare each part
-                    for i, (exp, mod) in enumerate(zip(expected_parts, model_parts)):
-                        if i == 1:  # Price field
-                            exp_clean = exp.replace('$', '').replace(',', '')
-                            mod_clean = mod.replace('$', '').replace(',', '')
-                            if exp_clean != mod_clean:
-                                mismatches.append(f"{key} price: expected '{exp}', got '{mod}'")
-                        elif i == 4:  # Inventory field (may have decimal places)
-                            exp_float = float(exp.replace(',', ''))
-                            mod_float = float(mod.replace(',', ''))
-                            if abs(exp_float - mod_float) > 0.0001:
-                                mismatches.append(f"{key} inventory: expected '{exp}', got '{mod}'")
-                        else:
-                            if exp.lower() != mod.lower():
-                                mismatches.append(f"{key} part {i}: expected '{exp}', got '{mod}'")
-                else:
-                    mismatches.append(f"{key}: format mismatch - expected '{expected_value}', got '{model_value}'")
-            else:
-                if expected_value != model_value:
-                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
-        
-        elif key == 'LowestInventoryProduct':
-            # Check product name and inventory
-            if ':' in expected_value and ':' in model_value:
-                expected_name, expected_inv = expected_value.rsplit(':', 1)
-                model_name, model_inv = model_value.rsplit(':', 1)
-                if expected_name.lower() != model_name.lower():
-                    mismatches.append(f"{key} name: expected '{expected_name}', got '{model_name}'")
-                exp_float = float(expected_inv.replace(',', ''))
-                mod_float = float(model_inv.replace(',', ''))
-                if abs(exp_float - mod_float) > 0.0001:
-                    mismatches.append(f"{key} inventory: expected '{expected_inv}', got '{model_inv}'")
-            else:
-                if expected_value != model_value:
-                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
-        
-        elif key in ['TotalRevenue', 'MinimumPurchaseRule']:
-            # For price/amount fields, normalize format
-            expected_clean = expected_value.replace('$', '').replace(',', '')
-            model_clean = model_value.replace('$', '').replace(',', '')
-            if expected_clean != model_clean:
-                mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
-        
-        elif key == 'BestsellerInSearch':
+
+        if key == 'BestsellerInSearch':
             # Check search term and count
             if expected_value.lower() != model_value.lower():
                 mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
@@ -158,13 +162,16 @@ def compare_answers(model_answer, expected_answer):
             if ':' in expected_value and ':' in model_value:
                 expected_name, expected_pct = expected_value.rsplit(':', 1)
                 model_name, model_pct = model_value.rsplit(':', 1)
-                if expected_name != model_name:
+                if expected_name.lower() != model_name.lower():
                     mismatches.append(f"{key} name: expected '{expected_name}', got '{model_name}'")
-                # Normalize percentage (20% vs 20 vs 0.20)
+                # Normalize percentage (20 vs 20% vs 20.0)
                 exp_pct_clean = expected_pct.replace('%', '').strip()
                 mod_pct_clean = model_pct.replace('%', '').strip()
-                if exp_pct_clean != mod_pct_clean:
-                    mismatches.append(f"{key} percentage: expected '{expected_pct}', got '{model_pct}'")
+                try:
+                    if float(exp_pct_clean) != float(mod_pct_clean):
+                        mismatches.append(f"{key} percentage: expected '{expected_pct}', got '{model_pct}'")
+                except ValueError:
+                    mismatches.append(f"{key} percentage should be numeric: got '{model_pct}'")
             else:
                 if expected_value != model_value:
                     mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
@@ -177,7 +184,7 @@ def compare_answers(model_answer, expected_answer):
                 if len(expected_parts) == 3 and len(model_parts) == 3:
                     exp_name, exp_email, exp_group = expected_parts
                     mod_name, mod_email, mod_group = model_parts
-                    if exp_name != mod_name:
+                    if exp_name.lower() != mod_name.lower():
                         mismatches.append(f"{key} name: expected '{exp_name}', got '{mod_name}'")
                     if exp_email.lower() != mod_email.lower():
                         mismatches.append(f"{key} email: expected '{exp_email}', got '{mod_email}'")
@@ -189,16 +196,17 @@ def compare_answers(model_answer, expected_answer):
                 if expected_value != model_value:
                     mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
         
-        elif key == 'MostRecentOrderDate':
-            # Date format may vary, do flexible comparison
-            if expected_value.lower() == 'none' and model_value.lower() == 'none':
-                continue
-            elif expected_value != model_value:
-                # Could add more flexible date parsing here if needed
-                mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
-        
+        elif key in ['ActiveRulesCount', 'TotalOrders', 'SameGroupCustomers']:
+            # Numeric counts: compare as int so "04" vs "4" doesn't fail
+            try:
+                if int(model_value) != int(expected_value):
+                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
+
         else:
-            # Exact match for other fields (counts, etc.)
+            # Exact string match for IDs and other text fields (e.g. MostRecentOrderID
+            # has leading zeros like "000000299" that must be preserved)
             if str(model_value) != str(expected_value):
                 mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
     

--- a/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/verify.py
@@ -103,7 +103,7 @@ def _normalize_bestseller(value):
     name, price, qty, sku, salable, status = parts
     try:
         return (
-            name.strip().lower(),
+            name.replace('&trade;', '™').strip().lower(),
             float(price.replace('$', '').replace(',', '').strip()),
             int(qty.strip()),
             sku.strip().lower(),

--- a/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/fitness_promotion_strategy/verify.py
@@ -38,6 +38,22 @@ def get_model_response():
         print(f"Error reading messages file: {str(e)}", file=sys.stderr)
         return None
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -45,28 +61,28 @@ def parse_answer_format(text):
     """
     if not text:
         return None
-    
+
     # Look for <answer>...</answer> pattern
     match = re.search(r'<answer>(.*?)</answer>', text, re.IGNORECASE | re.DOTALL)
     if not match:
         return None
-    
+
     answer_content = match.group(1).strip()
-    
+
     # Parse each line
     result = {}
     lines = answer_content.split('\n')
-    
+
     # Skip the check for exact number of lines - just parse what we have
     # if len(lines) != 13:
     #     print(f"Error: Expected 13 lines in answer, got {len(lines)}", file=sys.stderr)
     #     return None
-    
+
     for line in lines:
         if '|' in line:
             key, value = line.split('|', 1)
-            result[key.strip()] = value.strip()
-    
+            result[key.strip()] = normalize_text(value.strip())
+
     return result
 
 def load_expected_answer(label_path):
@@ -77,13 +93,13 @@ def load_expected_answer(label_path):
     try:
         with open(label_path, 'r') as f:
             lines = f.read().strip().split('\n')
-        
+
         expected = {}
         for line in lines:
             if '|' in line:
                 key, value = line.split('|', 1)
-                expected[key.strip()] = value.strip()
-        
+                expected[key.strip()] = normalize_text(value.strip())
+
         return expected
     except Exception as e:
         print(f"Error reading label file: {str(e)}", file=sys.stderr)

--- a/tasks/playwright_webarena/standard/shopping_admin/marketing_customer_analysis/description.md
+++ b/tasks/playwright_webarena/standard/shopping_admin/marketing_customer_analysis/description.md
@@ -44,7 +44,7 @@ Perform a comprehensive marketing and customer analysis workflow in the Magento 
 
 6. Finally, let's review overall business performance metrics from the main dashboard:
    Go to Dashboard and identify:
-   - The names and sales quantities of the products that are both the best-selling and most expensive
+   - Among the products tied for the highest sales quantity in the Bestsellers table, identify the one with the highest price - record its name and sales quantity
    - The total revenue displayed on the dashboard
 
 7. Compile all your findings and must output them in the following exact format at last:

--- a/tasks/playwright_webarena/standard/shopping_admin/marketing_customer_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/marketing_customer_analysis/verify.py
@@ -19,7 +19,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None
@@ -33,6 +33,7 @@ def get_model_response():
             if (
                 message.get("role") == "assistant"
                 and message.get("status") == "completed"
+                and message.get("type") == "message"
             ):
                 content = message.get("content", [])
                 for item in content:
@@ -111,45 +112,124 @@ def compare_answers(model_answer, expected_answer):
     for key, expected_value in expected_answer.items():
         model_value = model_answer.get(key, "")
 
-        # Special handling for different types of values
         if key == "Top2SearchTerms":
-            # Check if both search terms are present with correct counts
-            expected_terms = expected_value.split(",")
-            model_terms = model_value.split(",")
-            if set(expected_terms) != set(model_terms):
+            # Two "term:count" entries separated by ',' — order-independent;
+            # term case-insensitive, count compared as int
+            expected_terms = set()
+            for item in expected_value.split(','):
+                item = item.strip()
+                term, count = item.rsplit(':', 1)
+                expected_terms.add((term.strip().lower(), int(count.strip())))
+            model_terms = set()
+            for item in model_value.split(','):
+                item = item.strip()
+                if ':' not in item:
+                    mismatches.append(f"{key}: malformed entry '{item}'")
+                    continue
+                term, count = item.rsplit(':', 1)
+                try:
+                    model_terms.add((term.strip().lower(), int(count.strip())))
+                except ValueError:
+                    mismatches.append(f"{key}: non-numeric count in '{item}'")
+            if expected_terms != model_terms:
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
 
+        elif key == "ZeroResultTerm":
+            # Single "term:count" — term case-insensitive, count as int
+            exp_term, exp_count = expected_value.rsplit(':', 1)
+            expected_pair = (exp_term.strip().lower(), int(exp_count.strip()))
+            if ':' not in model_value:
+                mismatches.append(f"{key}: malformed value '{model_value}'")
+            else:
+                mod_term, mod_count = model_value.rsplit(':', 1)
+                try:
+                    model_pair = (mod_term.strip().lower(), int(mod_count.strip()))
+                    if expected_pair != model_pair:
+                        mismatches.append(
+                            f"{key}: expected '{expected_value}', got '{model_value}'"
+                        )
+                except ValueError:
+                    mismatches.append(f"{key}: non-numeric count in '{model_value}'")
+
         elif key == "EmailVerification":
-            # Check email verification status
-            expected_emails = dict(
-                item.split(":") for item in expected_value.split(",")
-            )
-            model_emails = dict(
-                item.split(":") for item in model_value.split(",") if ":" in item
-            )
+            # "email:yes/no" entries separated by ',' — email & status case-insensitive
+            expected_emails = {}
+            for item in expected_value.split(','):
+                email, status = item.rsplit(':', 1)
+                expected_emails[email.strip().lower()] = status.strip().lower()
+            model_emails = {}
+            for item in model_value.split(','):
+                item = item.strip()
+                if ':' not in item:
+                    mismatches.append(f"{key}: malformed entry '{item}'")
+                    continue
+                email, status = item.rsplit(':', 1)
+                model_emails[email.strip().lower()] = status.strip().lower()
             if expected_emails != model_emails:
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
 
         elif key == "CouponCodes":
-            # Check if coupon code and rule name are present
-            if "H20" not in model_value or "Luma water bottle" not in model_value:
+            # "code:rule_name" entries separated by ',' — code case-sensitive
+            # (coupon codes are typically uppercase tokens), rule name case-insensitive
+            expected_coupons = set()
+            for item in expected_value.split(','):
+                code, rule = item.split(':', 1)
+                expected_coupons.add((code.strip(), rule.strip().lower()))
+            model_coupons = set()
+            for item in model_value.split(','):
+                item = item.strip()
+                if ':' not in item:
+                    mismatches.append(f"{key}: malformed entry '{item}'")
+                    continue
+                code, rule = item.split(':', 1)
+                model_coupons.add((code.strip(), rule.strip().lower()))
+            if expected_coupons != model_coupons:
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
 
         elif key == "TopProduct":
-            # Check if product name and quantity match
-            if expected_value != model_value:
-                mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
-                )
+            # "name:quantity" — name case-insensitive, qty as int
+            if ':' in expected_value and ':' in model_value:
+                exp_name, exp_qty = expected_value.rsplit(':', 1)
+                mod_name, mod_qty = model_value.rsplit(':', 1)
+                if exp_name.strip().lower() != mod_name.strip().lower():
+                    mismatches.append(f"{key} name: expected '{exp_name}', got '{mod_name}'")
+                try:
+                    if int(exp_qty.strip()) != int(mod_qty.strip()):
+                        mismatches.append(f"{key} quantity: expected '{exp_qty}', got '{mod_qty}'")
+                except ValueError:
+                    mismatches.append(f"{key} quantity should be numeric: got '{mod_qty}'")
+            else:
+                if expected_value != model_value:
+                    mismatches.append(
+                        f"{key}: expected '{expected_value}', got '{model_value}'"
+                    )
+
+        elif key in ("TotalSearchTerms", "ActiveRulesCount", "SubscribedCount"):
+            # Numeric counts: compare as int so "04" vs "4" doesn't fail
+            try:
+                if int(model_value) != int(expected_value):
+                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
+
+        elif key == "TotalRevenue":
+            # Strip $ and , then compare as float so "$0.00" matches "0" / "0.00"
+            exp_clean = expected_value.replace('$', '').replace(',', '').strip()
+            mod_clean = model_value.replace('$', '').replace(',', '').strip()
+            try:
+                if float(exp_clean) != float(mod_clean):
+                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
 
         else:
-            # Exact match for other fields
+            # Fallback exact match for any unrecognized key
             if model_value != expected_value:
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"
@@ -183,32 +263,29 @@ async def verify() -> bool:
 
     # Get model's response from MCP_MESSAGES
     model_response = get_model_response()
-    if model_response:
-        print("Found model response, parsing answer format...", file=sys.stderr)
-        model_answer = parse_answer_format(model_response)
+    if not model_response:
+        print("No model response found", file=sys.stderr)
+        return False
 
-        if model_answer:
-            print("\n=== Model Answer Parsed ===", file=sys.stderr)
-            for key, value in model_answer.items():
-                print(f"{key}: {value}", file=sys.stderr)
-
-            # Compare answers
-            answer_match = compare_answers(model_answer, expected_answer)
-            if not answer_match:
-                print("\nModel answer does not match expected answer", file=sys.stderr)
-                return False
-            print("\n✓ Model answer matches expected answer", file=sys.stderr)
-        else:
-            print(
-                "Warning: Could not parse answer format from model response",
-                file=sys.stderr,
-            )
-            print("Will proceed with browser verification only", file=sys.stderr)
-    else:
+    print("Found model response, parsing answer format...", file=sys.stderr)
+    model_answer = parse_answer_format(model_response)
+    if not model_answer:
         print(
-            "No model response found, proceeding with browser verification",
+            "Could not parse answer format from model response",
             file=sys.stderr,
         )
+        return False
+
+    print("\n=== Model Answer Parsed ===", file=sys.stderr)
+    for key, value in model_answer.items():
+        print(f"{key}: {value}", file=sys.stderr)
+
+    # Compare answers
+    answer_match = compare_answers(model_answer, expected_answer)
+    if not answer_match:
+        print("\nModel answer does not match expected answer", file=sys.stderr)
+        return False
+    print("\n✓ Model answer matches expected answer", file=sys.stderr)
 
     # Browser verification - only check customer creation (the critical task requirement)
     print("\n=== Starting Browser Verification ===", file=sys.stderr)

--- a/tasks/playwright_webarena/standard/shopping_admin/marketing_customer_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/marketing_customer_analysis/verify.py
@@ -47,6 +47,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the new multi-line <answer>xxx</answer> format from the agent's output.
@@ -73,7 +89,7 @@ def parse_answer_format(text):
     for line in lines:
         if "|" in line:
             key, value = line.split("|", 1)
-            result[key.strip()] = value.strip()
+            result[key.strip()] = normalize_text(value.strip())
 
     return result
 
@@ -91,7 +107,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping_admin/ny_expansion_analysis/description.md
+++ b/tasks/playwright_webarena/standard/shopping_admin/ny_expansion_analysis/description.md
@@ -11,13 +11,13 @@ Our company is planning to expand sales operations to New York state and needs a
 
 3. Since we're expanding to New York, we need check tax:
    - Find and record the exact tax rate for New York state
-   - Compare it with California's tax rate - record which state has a higher rate
+   - Also record California's tax rate as a reference
    - Count how many different US states currently have tax configurations
 
-4. You need to understand our order status of stores processing for the NY market:
-   - Filter orders to show only statuses that are 'Visible On Storefront = Yes'
-   - Among these visible statuses, identify if exists one has the status code 'processing' (Yes or No),
-   - Check if this 'processing' status is set as a 'Default Status' (Yes or No)
+4. Review the order status configuration for the NY market:
+   In Stores → Settings → Order Status, focus on rows where 'Visible On Storefront' is 'Yes':
+   - Identify if any of them has the status code 'processing' (Yes or No)
+   - For that 'processing' status, record whether 'Default Status' is Yes or No
 
 
 5. Since New York orders might need special handling, check all stores:
@@ -25,7 +25,7 @@ Our company is planning to expand sales operations to New York state and needs a
    - Record the store code for the first Main Website Store
 
 6. For inventory planning, check the sources of it:
-   - Check if the Default Source is currently 'Enabled' or shows as 'Disabled' for Pickup Location
+   - For the Default Source, check whether its 'Pickup Location' column is 'Enabled' or 'Disabled'
    - Click the 'Edit' link for the Default Source and check if there's a 'State/Province' field (Yes or No)
 
 7. Finally, return to the Dashboard and examine the revenue metrics:
@@ -38,19 +38,18 @@ Our company is planning to expand sales operations to New York state and needs a
 <answer>
 Lifetime_Sales_Amount|amount
 Cheap_Bestseller_Name|name
-Second_Bestseller_Price|price
-Second_Bestseller_Quantity|quantity
+Cheap_Bestseller_Price|price
+Cheap_Bestseller_Quantity|quantity
 Product_In_Last_Orders|yes_or_no
 NY_Tax_Rate|rate
 CA_Tax_Rate|rate
-Higher_Tax_State|state
 Total_States_With_Tax|count
 Processing_Visible_Storefront|Yes_or_No
 Processing_Default_Status|Yes_or_No
 Number_Of_Websites|count
 Main_Store_Code|code
 Default_Source_Pickup_Status|status
-Default_Source_State|state_or_none
+Default_Source_State|yes_or_no
 Dashboard_Revenue|amount
 Tax_Shipping_Zero|yes_or_no
 </answer>
@@ -61,19 +60,18 @@ Tax_Shipping_Zero|yes_or_no
 <answer>
 Lifetime_Sales_Amount|$XX.XX
 Cheap_Bestseller_Name|Product Name Here
-Second_Bestseller_Price|$XX.XX
-Second_Bestseller_Quantity|XX
+Cheap_Bestseller_Price|$XX.XX
+Cheap_Bestseller_Quantity|XX
 Product_In_Last_Orders|Yes/No
 NY_Tax_Rate|X.XXXX
 CA_Tax_Rate|X.XXXX
-Higher_Tax_State|XX
 Total_States_With_Tax|XX
 Processing_Visible_Storefront|Yes/No
 Processing_Default_Status|Yes/No
 Number_Of_Websites|X
 Main_Store_Code|code_here
 Default_Source_Pickup_Status|Enabled/Disabled
-Default_Source_State|State or None
+Default_Source_State|Yes/No
 Dashboard_Revenue|$XX.XX
 Tax_Shipping_Zero|Yes/No
 </answer>

--- a/tasks/playwright_webarena/standard/shopping_admin/ny_expansion_analysis/label.txt
+++ b/tasks/playwright_webarena/standard/shopping_admin/ny_expansion_analysis/label.txt
@@ -1,17 +1,16 @@
 Lifetime_Sales_Amount|$0.00
 Cheap_Bestseller_Name|Sprite Yoga Strap 6 foot
-Second_Bestseller_Price|$14.00
-Second_Bestseller_Quantity|6
+Cheap_Bestseller_Price|$14.00
+Cheap_Bestseller_Quantity|6
 Product_In_Last_Orders|No
 NY_Tax_Rate|8.3750
 CA_Tax_Rate|8.2500
-Higher_Tax_State|NY
-Total_States_With_Tax|2
+Total_States_With_Tax|3
 Processing_Visible_Storefront|Yes
 Processing_Default_Status|Yes
 Number_Of_Websites|1
 Main_Store_Code|main_website_store
-Default_Source_Pickup_Status|Enabled
-Default_Source_State|No
+Default_Source_Pickup_Status|Disabled
+Default_Source_State|Yes
 Dashboard_Revenue|$0.00
 Tax_Shipping_Zero|Yes

--- a/tasks/playwright_webarena/standard/shopping_admin/ny_expansion_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/ny_expansion_analysis/verify.py
@@ -66,6 +66,22 @@ def get_model_response():
         print(f"ERROR: Unexpected error reading messages file: {str(e)}", file=sys.stderr)
         return None
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -119,7 +135,7 @@ def parse_answer_format(text):
             
         key, value = parts
         key = key.strip()
-        value = value.strip()
+        value = normalize_text(value.strip())
         
         if not key:
             print(f"ERROR: Empty key in line: {line}", file=sys.stderr)
@@ -157,7 +173,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if '|' in line:
                 key, value = line.split('|', 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
         
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping_admin/ny_expansion_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/ny_expansion_analysis/verify.py
@@ -11,7 +11,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("ERROR: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None
@@ -39,7 +39,11 @@ def get_model_response():
         
         # Find the last assistant message
         for message in reversed(messages):
-            if message.get('role') == 'assistant' and message.get('status') == 'completed':
+            if (
+                message.get('role') == 'assistant'
+                and message.get('status') == 'completed'
+                and message.get('type') == 'message'
+            ):
                 content = message.get('content', [])
                 if not content:
                     print("WARNING: Assistant message has empty content", file=sys.stderr)
@@ -90,9 +94,9 @@ def parse_answer_format(text):
     
     # Expected keys that should be present
     expected_keys = [
-        'Lifetime_Sales_Amount', 'Cheap_Bestseller_Name', 'Second_Bestseller_Price',
-        'Second_Bestseller_Quantity', 'Product_In_Last_Orders', 'NY_Tax_Rate',
-        'CA_Tax_Rate', 'Higher_Tax_State', 'Total_States_With_Tax',
+        'Lifetime_Sales_Amount', 'Cheap_Bestseller_Name', 'Cheap_Bestseller_Price',
+        'Cheap_Bestseller_Quantity', 'Product_In_Last_Orders', 'NY_Tax_Rate',
+        'CA_Tax_Rate', 'Total_States_With_Tax',
         'Processing_Visible_Storefront', 'Processing_Default_Status',
         'Number_Of_Websites', 'Main_Store_Code', 'Default_Source_Pickup_Status',
         'Default_Source_State', 'Dashboard_Revenue', 'Tax_Shipping_Zero'
@@ -172,60 +176,54 @@ def compare_answers(model_answer, expected_answer):
     mismatches = []
     for key, expected_value in expected_answer.items():
         model_value = model_answer.get(key, '')
-        
-        # Special handling for different types of values
-        if key in ['Lifetime_Sales_Amount', 'Second_Bestseller_Price', 'Dashboard_Revenue']:
-            # For price/amount fields, normalize format
-            expected_clean = expected_value.replace('$', '').replace(',', '')
-            model_clean = model_value.replace('$', '').replace(',', '')
-            if expected_clean != model_clean:
-                mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
-        
-        elif key in ['NY_Tax_Rate', 'CA_Tax_Rate']:
-            # Tax rates - allow different decimal formats
-            expected_clean = expected_value.replace('%', '').strip()
-            model_clean = model_value.replace('%', '').strip()
-            # Convert to float for comparison
+
+        if key in ['Lifetime_Sales_Amount', 'Cheap_Bestseller_Price', 'Dashboard_Revenue']:
+            # Price/amount fields: strip $ and , then compare as float so
+            # "$0.00" matches "0" / "0.00"
+            expected_clean = expected_value.replace('$', '').replace(',', '').strip()
+            model_clean = model_value.replace('$', '').replace(',', '').strip()
             try:
                 if float(expected_clean) != float(model_clean):
                     mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
             except ValueError:
-                if expected_clean != model_clean:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
+
+        elif key in ['NY_Tax_Rate', 'CA_Tax_Rate']:
+            # Tax rates: strip % then compare as float
+            expected_clean = expected_value.replace('%', '').strip()
+            model_clean = model_value.replace('%', '').strip()
+            try:
+                if float(expected_clean) != float(model_clean):
                     mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
-        
-        elif key in ['Product_In_Last_Orders', 'Processing_Visible_Storefront', 'Processing_Default_Status', 'Tax_Shipping_Zero']:
-            # Yes/No fields - case insensitive
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
+
+        elif key in [
+            'Product_In_Last_Orders',
+            'Processing_Visible_Storefront',
+            'Processing_Default_Status',
+            'Tax_Shipping_Zero',
+            'Default_Source_State',
+        ]:
+            # Yes/No fields — case-insensitive
             if model_value.lower() != expected_value.lower():
                 mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
-        
-        elif key == 'Empty_Rows_Yes_Effect':
-            # Allow flexible descriptions for this field
-            # Just check if model provided some reasonable description
-            if not model_value or len(model_value) < 5:
-                mismatches.append(f"{key}: expected meaningful description, got '{model_value}'")
-        
-        elif key == 'Order_Status_Options':
-            # Check if main options are mentioned
-            expected_options = set(opt.strip() for opt in expected_value.split(','))
-            model_options = set(opt.strip() for opt in model_value.split(','))
-            if expected_options != model_options:
+
+        elif key in ['Cheap_Bestseller_Quantity', 'Total_States_With_Tax', 'Number_Of_Websites']:
+            # Numeric counts: compare as int so "04" / "4" / "4.0" don't fail
+            try:
+                if int(float(model_value)) != int(float(expected_value)):
+                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
+
+        elif key in ['Cheap_Bestseller_Name', 'Default_Source_Pickup_Status', 'Main_Store_Code']:
+            # String fields — case-insensitive
+            if model_value.strip().lower() != expected_value.strip().lower():
                 mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
-        
-        elif key == 'Chart_Disabled_Message':
-            # Allow some flexibility in message text
-            # Check for key words
-            if 'disabled' not in model_value.lower() and 'enable' not in model_value.lower():
-                mismatches.append(f"{key}: expected message about chart being disabled, got '{model_value}'")
-        
-        elif key == 'Default_Source_State':
-            # Handle 'None' or empty state
-            expected_normalized = expected_value.lower() if expected_value.lower() != 'none' else ''
-            model_normalized = model_value.lower() if model_value.lower() != 'none' else ''
-            if expected_normalized != model_normalized:
-                mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
-        
+
         else:
-            # Exact match for other fields
+            # Fallback exact match for any unrecognized key
             if model_value != expected_value:
                 mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
     

--- a/tasks/playwright_webarena/standard/shopping_admin/products_sales_analysis/description.md
+++ b/tasks/playwright_webarena/standard/shopping_admin/products_sales_analysis/description.md
@@ -5,16 +5,16 @@ Perform a comprehensive products and sales analysis in the Magento Admin panel t
 1. if need to login, login with username 'admin' and password 'admin1234'
 
 2. Analyze product inventory and catalog details, perform the following:
-   - Search for all products containing 'Yoga' in their name - count the exact number of results
-   - Clear the search and find the product with SKU 'WH11' - record its exact price
+   - Filter by Name containing 'Yoga' - count the exact number of results
+   - Clear all filters and find the product with SKU 'WH11' - record its exact price
    - Apply a filter to show only products with Quantity = 0.0000 - count how many products match
 
 3. To identify top-selling products and revenue metrics, navigate to the Dashboard and from the Bestsellers table:
-   - Identify the product with lowest price and lowest quantity - record the product name and quantity sold
+   - Among the products tied for the lowest sales quantity, identify the one with the lowest price - record its name and sales quantity
    - Find the second cheapest product in the table - record its exact quantity sold
    - Note the total Revenue amount displayed in the dashboard
 
-4. Father all customers' information and demographics:
+4. Gather all customers' information and demographics:
    - Find customer 'Sarah Miller' - record her exact email address
    - Count the total number of customers shown in the grid
 
@@ -30,7 +30,7 @@ YogaProducts|count
 WH11Price|price
 ZeroQuantityProducts|count
 LowestProduct|name:quantity
-QuestLumaflexQuantity|quantity
+SecondCheapestQuantity|quantity
 DashboardRevenue|amount
 SarahMillerEmail|email
 TotalCustomers|count
@@ -46,9 +46,9 @@ YogaProducts|XX
 WH11Price|$XX.XX
 ZeroQuantityProducts|XX
 LowestProduct|Product Name Here:XX
-QuestLumaflexQuantity|XX
+SecondCheapestQuantity|XX
 DashboardRevenue|$XX.XX
-SarahMillerEmail|email@example.com
+SarahMillerEmail|<customer email>
 TotalCustomers|XX
 PendingOrders|X
 GraceNguyenOrderID|00000XXXX

--- a/tasks/playwright_webarena/standard/shopping_admin/products_sales_analysis/label.txt
+++ b/tasks/playwright_webarena/standard/shopping_admin/products_sales_analysis/label.txt
@@ -1,10 +1,10 @@
-YogaProducts|171
+YogaProducts|172
 WH11Price|$54.00
 ZeroQuantityProducts|150
-LowestProduct|Sprite Stasis Ball 55 cm foot:5
-QuestLumaflexQuantity|6
+LowestProduct|Sprite Stasis Ball 55 cm:5
+SecondCheapestQuantity|6
 DashboardRevenue|$0.00
 SarahMillerEmail|helloworld@yahoo.com
-TotalCustomers|72
+TotalCustomers|70
 PendingOrders|10
 GraceNguyenOrderID|000000189

--- a/tasks/playwright_webarena/standard/shopping_admin/products_sales_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/products_sales_analysis/verify.py
@@ -40,6 +40,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -86,7 +102,7 @@ def parse_answer_format(text):
             print(f"Error: Invalid line format: {line}", file=sys.stderr)
             return None
             
-        key, value = parts[0].strip(), parts[1].strip()
+        key, value = parts[0].strip(), normalize_text(parts[1].strip())
         
         if not key or not value:
             print(f"Error: Empty key or value in line: {line}", file=sys.stderr)
@@ -116,7 +132,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping_admin/products_sales_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/products_sales_analysis/verify.py
@@ -12,7 +12,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None
@@ -26,6 +26,7 @@ def get_model_response():
             if (
                 message.get("role") == "assistant"
                 and message.get("status") == "completed"
+                and message.get("type") == "message"
             ):
                 content = message.get("content", [])
                 for item in content:
@@ -71,7 +72,7 @@ def parse_answer_format(text):
     # Expected keys for validation
     expected_keys = [
         "YogaProducts", "WH11Price", "ZeroQuantityProducts", "LowestProduct",
-        "QuestLumaflexQuantity", "DashboardRevenue", "SarahMillerEmail",
+        "SecondCheapestQuantity", "DashboardRevenue", "SarahMillerEmail",
         "TotalCustomers", "PendingOrders", "GraceNguyenOrderID"
     ]
 
@@ -136,16 +137,18 @@ def compare_answers(model_answer, expected_answer):
     for key, expected_value in expected_answer.items():
         model_value = model_answer.get(key, "")
 
-        # Special handling for different types of values
         if key == "LowestProduct":
-            # Check if product name and quantity match (format: "Product Name:quantity")
+            # "name:quantity" — name case-insensitive, qty as int
             if ":" in expected_value and ":" in model_value:
-                expected_name, expected_qty = expected_value.rsplit(":", 1)
-                model_name, model_qty = model_value.rsplit(":", 1)
-                if expected_name != model_name or expected_qty != model_qty:
-                    mismatches.append(
-                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                    )
+                exp_name, exp_qty = expected_value.rsplit(":", 1)
+                mod_name, mod_qty = model_value.rsplit(":", 1)
+                if exp_name.strip().lower() != mod_name.strip().lower():
+                    mismatches.append(f"{key} name: expected '{exp_name}', got '{mod_name}'")
+                try:
+                    if int(exp_qty.strip()) != int(mod_qty.strip()):
+                        mismatches.append(f"{key} quantity: expected '{exp_qty}', got '{mod_qty}'")
+                except ValueError:
+                    mismatches.append(f"{key} quantity should be numeric: got '{mod_qty}'")
             else:
                 if expected_value != model_value:
                     mismatches.append(
@@ -153,23 +156,41 @@ def compare_answers(model_answer, expected_answer):
                     )
 
         elif key in ["WH11Price", "DashboardRevenue"]:
-            # For price/amount fields, normalize format
-            expected_clean = expected_value.replace("$", "").replace(",", "")
-            model_clean = model_value.replace("$", "").replace(",", "")
-            if expected_clean != model_clean:
-                mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
-                )
+            # Price/amount fields: strip $ and , then compare as float so
+            # "$54.00" matches "54" / "54.0"
+            expected_clean = expected_value.replace("$", "").replace(",", "").strip()
+            model_clean = model_value.replace("$", "").replace(",", "").strip()
+            try:
+                if float(expected_clean) != float(model_clean):
+                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
+
+        elif key in [
+            "YogaProducts",
+            "ZeroQuantityProducts",
+            "SecondCheapestQuantity",
+            "TotalCustomers",
+            "PendingOrders",
+        ]:
+            # Numeric counts: compare as int so "04" / "4" / "4.0" don't fail
+            try:
+                if int(float(model_value)) != int(float(expected_value)):
+                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
 
         elif key == "SarahMillerEmail":
-            # Email should match exactly
+            # Email — case-insensitive
             if model_value.lower() != expected_value.lower():
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
 
         else:
-            # Exact match for other fields
+            # Exact string match for IDs and other text fields (e.g.
+            # GraceNguyenOrderID has leading zeros like "000000189" that must
+            # be preserved)
             if model_value != expected_value:
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"

--- a/tasks/playwright_webarena/standard/shopping_admin/sales_inventory_analysis/description.md
+++ b/tasks/playwright_webarena/standard/shopping_admin/sales_inventory_analysis/description.md
@@ -6,21 +6,21 @@ Perform a comprehensive sales and inventory analysis by extracting specific metr
 
 2. To analyze product inventory and identify key items, check all products:
    - Search for all products containing 'Sprite' in their name - count the exact number of results
-   - Clear the search and filter products by Quantity = 100.0000 - count how many products match
+   - Clear all filters and filter products by Quantity = 100.0000 - count how many products match
    - Find the product with SKU 'WS12' - record its exact name and price
 
 3. To understand sales performance and order status, we need check all orders:
    - Search for all orders with 'Pending' status - count the total number
-   - Find Grace Nguyen's Complete and the most cheap order - record the order ID (starts with "000")
+   - Find Grace Nguyen's order with Complete status and the lowest price - record its order ID (starts with "000")
    - Find the order with the highest Grand Total - record the customer name and amount
 
 4. To examine bestselling products and search trends, from the main page:
-   - In the Bestsellers table, identify the product with most quantity but and lowest price - record its name and quantity sold
+   - Among the products tied for the highest sales quantity in the Bestsellers table, identify the one with the lowest price - record its name and sales quantity
    - Find 'Overnight Duffle' and record its exact price
    - In the Top Search Terms table, find 'hollister' and record its position number (1st, 2nd, etc.)
 
 5. To analyze customer demographics and account information, go to All Customers:
-   - Search for customers with its email address containing 'costello' - count the results
+   - Search for customers whose email address contains 'costello' - count the results
    - Find Sarah Miller's customer record - record her Group and extract Customer Since date
 
 6. To review payment status and billing information, navigate to Invoices:

--- a/tasks/playwright_webarena/standard/shopping_admin/sales_inventory_analysis/description.md
+++ b/tasks/playwright_webarena/standard/shopping_admin/sales_inventory_analysis/description.md
@@ -21,7 +21,7 @@ Perform a comprehensive sales and inventory analysis by extracting specific metr
 
 5. To analyze customer demographics and account information, go to All Customers:
    - Search for customers whose email address contains 'costello' - count the results
-   - Find Sarah Miller's customer record - record her Group and extract Customer Since date
+   - Find Sarah Miller's customer record - record her Group and the full Customer Since timestamp exactly as shown in Magento (e.g. `Jan 7, 2022 10:15:42 AM`)
 
 6. To review payment status and billing information, navigate to Invoices:
    - Find all invoices with 'Paid' status - count them
@@ -60,7 +60,7 @@ CheapProduct|Product Name:XX
 OvernightDufflePrice|$XX.XX
 HollisterPosition|Xth
 CostelloCustomers|X
-SarahMillerInfo|Group Name:MMM DD, YYYY
+SarahMillerInfo|Group Name:MMM DD, YYYY H:MM:SS AM/PM
 PaidInvoices|X
 Invoice002BillTo|Customer Name
 </answer>

--- a/tasks/playwright_webarena/standard/shopping_admin/sales_inventory_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/sales_inventory_analysis/verify.py
@@ -12,7 +12,7 @@ def get_model_response():
     Returns the last assistant message text.
     """
     messages_path = os.getenv("MCP_MESSAGES")
-    print(f"MCP_MESSAGES: {messages_path}")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
         print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
         return None
@@ -139,71 +139,58 @@ def compare_answers(model_answer, expected_answer):
     for key, expected_value in expected_answer.items():
         model_value = model_answer.get(key, "")
 
-        # Special handling for different types of values
         if key == "WS12Info":
-            # Check if product name and price match (format: name:price)
+            # "name:price" — name case-insensitive, price as float
             if ":" in expected_value and ":" in model_value:
-                expected_name, expected_price = expected_value.rsplit(":", 1)
-                model_name, model_price = model_value.rsplit(":", 1)
-                # Normalize price format
-                expected_price_clean = expected_price.replace("$", "").replace(",", "")
-                model_price_clean = model_price.replace("$", "").replace(",", "")
-                if (
-                    expected_name != model_name
-                    or expected_price_clean != model_price_clean
-                ):
-                    mismatches.append(
-                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                    )
+                exp_name, exp_price = expected_value.rsplit(":", 1)
+                mod_name, mod_price = model_value.rsplit(":", 1)
+                if exp_name.strip().lower() != mod_name.strip().lower():
+                    mismatches.append(f"{key} name: expected '{exp_name}', got '{mod_name}'")
+                exp_price_clean = exp_price.replace("$", "").replace(",", "").strip()
+                mod_price_clean = mod_price.replace("$", "").replace(",", "").strip()
+                try:
+                    if float(exp_price_clean) != float(mod_price_clean):
+                        mismatches.append(f"{key} price: expected '{exp_price}', got '{mod_price}'")
+                except ValueError:
+                    mismatches.append(f"{key} price should be numeric: got '{mod_price}'")
             else:
                 if expected_value != model_value:
                     mismatches.append(
                         f"{key}: expected '{expected_value}', got '{model_value}'"
                     )
-
-        elif key == "GraceOrderID":
-            # Order ID should start with "000" and match exactly
-            if not model_value.startswith("000"):
-                mismatches.append(
-                    f"{key}: expected to start with '000', got '{model_value}'"
-                )
-            elif model_value != expected_value:
-                mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
-                )
 
         elif key == "HighestOrderInfo":
-            # Check format customer:amount
+            # "customer:amount" — customer case-insensitive, amount as float
             if ":" in expected_value and ":" in model_value:
-                expected_customer, expected_amount = expected_value.rsplit(":", 1)
-                model_customer, model_amount = model_value.rsplit(":", 1)
-                # Normalize amount format
-                expected_amount_clean = expected_amount.replace("$", "").replace(
-                    ",", ""
-                )
-                model_amount_clean = model_amount.replace("$", "").replace(",", "")
-                if (
-                    expected_customer != model_customer
-                    or expected_amount_clean != model_amount_clean
-                ):
-                    mismatches.append(
-                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                    )
+                exp_customer, exp_amount = expected_value.rsplit(":", 1)
+                mod_customer, mod_amount = model_value.rsplit(":", 1)
+                if exp_customer.strip().lower() != mod_customer.strip().lower():
+                    mismatches.append(f"{key} customer: expected '{exp_customer}', got '{mod_customer}'")
+                exp_amount_clean = exp_amount.replace("$", "").replace(",", "").strip()
+                mod_amount_clean = mod_amount.replace("$", "").replace(",", "").strip()
+                try:
+                    if float(exp_amount_clean) != float(mod_amount_clean):
+                        mismatches.append(f"{key} amount: expected '{exp_amount}', got '{mod_amount}'")
+                except ValueError:
+                    mismatches.append(f"{key} amount should be numeric: got '{mod_amount}'")
             else:
                 if expected_value != model_value:
                     mismatches.append(
                         f"{key}: expected '{expected_value}', got '{model_value}'"
                     )
 
-        elif key == "Position2Product":
-            # Check if product name and quantity match
+        elif key == "CheapProduct":
+            # "name:quantity" — name case-insensitive, qty as int
             if ":" in expected_value and ":" in model_value:
-                expected_name, expected_qty = expected_value.rsplit(":", 1)
-                model_name, model_qty = model_value.rsplit(":", 1)
-                if expected_name != model_name or expected_qty != model_qty:
-                    mismatches.append(
-                        f"{key}: expected '{expected_value}', got '{model_value}'"
-                    )
+                exp_name, exp_qty = expected_value.rsplit(":", 1)
+                mod_name, mod_qty = model_value.rsplit(":", 1)
+                if exp_name.strip().lower() != mod_name.strip().lower():
+                    mismatches.append(f"{key} name: expected '{exp_name}', got '{mod_name}'")
+                try:
+                    if int(exp_qty.strip()) != int(mod_qty.strip()):
+                        mismatches.append(f"{key} quantity: expected '{exp_qty}', got '{mod_qty}'")
+                except ValueError:
+                    mismatches.append(f"{key} quantity should be numeric: got '{mod_qty}'")
             else:
                 if expected_value != model_value:
                     mismatches.append(
@@ -211,36 +198,32 @@ def compare_answers(model_answer, expected_answer):
                     )
 
         elif key == "OvernightDufflePrice":
-            # Normalize price format
-            expected_clean = expected_value.replace("$", "").replace(",", "")
-            model_clean = model_value.replace("$", "").replace(",", "")
-            if expected_clean != model_clean:
-                mismatches.append(
-                    f"{key}: expected '{expected_value}', got '{model_value}'"
-                )
+            # Strip $ and , then compare as float
+            expected_clean = expected_value.replace("$", "").replace(",", "").strip()
+            model_clean = model_value.replace("$", "").replace(",", "").strip()
+            try:
+                if float(expected_clean) != float(model_clean):
+                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
 
         elif key == "HollisterPosition":
-            # Position format (1st, 2nd, 3rd, etc.)
-            if model_value.lower() != expected_value.lower():
+            # Position format (1st, 2nd, 3rd, etc.) — case-insensitive
+            if model_value.strip().lower() != expected_value.strip().lower():
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
 
         elif key == "SarahMillerInfo":
-            # Format: group:date
+            # "group:date" — both case-insensitive exact match
+            # (split on first ':' only; the date itself contains ':' for the time)
             if ":" in expected_value and ":" in model_value:
-                expected_group, expected_date = expected_value.split(":", 1)
-                model_group, model_date = model_value.split(":", 1)
-                # Allow some flexibility in date format
-                if expected_group != model_group:
-                    mismatches.append(
-                        f"{key}: expected group '{expected_group}', got '{model_group}'"
-                    )
-                # For date, check if key parts match
-                if not (expected_date in model_date or model_date in expected_date):
-                    mismatches.append(
-                        f"{key}: expected date '{expected_date}', got '{model_date}'"
-                    )
+                exp_group, exp_date = expected_value.split(":", 1)
+                mod_group, mod_date = model_value.split(":", 1)
+                if exp_group.strip().lower() != mod_group.strip().lower():
+                    mismatches.append(f"{key} group: expected '{exp_group}', got '{mod_group}'")
+                if exp_date.strip().lower() != mod_date.strip().lower():
+                    mismatches.append(f"{key} date: expected '{exp_date}', got '{mod_date}'")
             else:
                 if expected_value != model_value:
                     mismatches.append(
@@ -248,14 +231,30 @@ def compare_answers(model_answer, expected_answer):
                     )
 
         elif key == "Invoice002BillTo":
-            # Name should match exactly
-            if model_value != expected_value:
+            # Customer name — case-insensitive
+            if model_value.strip().lower() != expected_value.strip().lower():
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"
                 )
 
+        elif key in [
+            "SpriteProducts",
+            "Quantity100Products",
+            "PendingOrders",
+            "CostelloCustomers",
+            "PaidInvoices",
+        ]:
+            # Numeric counts: compare as int so "04" / "4" / "4.0" don't fail
+            try:
+                if int(float(model_value)) != int(float(expected_value)):
+                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
+
         else:
-            # Exact match for count fields and other numeric values
+            # Exact string match for IDs and other text fields (e.g.
+            # GraceOrderID has leading zeros like "000000114" that must be
+            # preserved)
             if model_value != expected_value:
                 mismatches.append(
                     f"{key}: expected '{expected_value}', got '{model_value}'"

--- a/tasks/playwright_webarena/standard/shopping_admin/sales_inventory_analysis/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/sales_inventory_analysis/verify.py
@@ -41,6 +41,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -88,7 +104,7 @@ def parse_answer_format(text):
             return None
             
         key, value = parts
-        result[key.strip()] = value.strip()
+        result[key.strip()] = normalize_text(value.strip())
     
     # Check if all expected keys are present
     missing_keys = set(expected_keys) - set(result.keys())
@@ -118,7 +134,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:

--- a/tasks/playwright_webarena/standard/shopping_admin/search_filtering_operations/description.md
+++ b/tasks/playwright_webarena/standard/shopping_admin/search_filtering_operations/description.md
@@ -7,23 +7,22 @@ Perform comprehensive search and filtering operations in the Magento Admin panel
 2. To analyze search behavior and term effectiveness, check the Search Terms of Marketing and perform complex filtering:
    - Search for all terms containing 'tank' in their name - count the exact number of results
    - Clear filters and find terms with exactly 0 results - count how many such terms exist
-   - Apply a filter to show only terms with more than 10 uses - record the term with highest uses and its count (You need to see how many there are and record them all.)
-   - Find the search term that has results between 20-30 - record its name and exact result count
+   - Apply a filter to show only terms with more than 10 uses - record the term with highest uses and its count
+   - Find the search terms that have results between 20-30 - record their names and exact result counts (You need to see how many there are and record them all.)
 
 3. To gather detailed marketing insights from search data, go to Search Terms in Reports:
    - Apply filter for terms with more than 15 hits - count total filtered results
-   - Find the term with ID between 10-15 that has the most results - record term name and result count (You need to see how many there are and record them all.)
+   - Find the term with ID between 10-15 that has the most results - record term name and result count
    - Filter to show only terms from "Default Store View" - count total results
 
 4. To examine real-time search trends and top performers, from the Dashboard, perform targeted searches:
-   - In the 'Top Search Terms' table, find the term with exactly 1 result - record its name and uses
-   - In the 'Last Search Terms' table, identify the term with the both the highest number of results and uses - record name and the number of results
-   - In the 'Bestsellers' tab, find the product at position #3 - record name and quantity
+   - In the 'Top Search Terms' table, find the terms with exactly 1 result - record their names and uses (You need to see how many there are and record them all.)
+   - In the 'Last Search Terms' table, identify the term with both the highest number of results and uses - record its name and number of results
 
-5. To identify patterns in search usage and results, navigate to Search Terms (main grid) in step 2:
+5. To identify patterns in search usage and results, return to the Search Terms grid (Marketing → Search Terms):
    - Sort by 'Uses' column (descending) - record the top term and its uses count
-   - Sort by 'Results' column (ascending) - record the first non-zero result term and its count
-   - Count total number of unique search terms in the system
+   - Sort by 'Results' column (ascending), then by 'Uses' (ascending) - record the first non-zero result term and its count
+   - Count the total number of search terms in the grid
 
 6. To provide a comprehensive report of all gathered data, compile all findings and output in the following exact format:
 
@@ -32,13 +31,12 @@ Perform comprehensive search and filtering operations in the Magento Admin panel
 TankSearchCount|count
 ZeroResultsCount|count
 HighestUseTerm|term:uses
-Results20to30Term|term1:results1|term2:result2|term3:result3|...
+Results20to30Term|term1:results1;term2:result2;term3:result3;...
 Hits15PlusCount|count
 ID10to15MaxResults|term:results
 DefaultStoreViewCount|count
-OneResultTerm|term1:uses1|term2:uses2|term3:uses3|...
+OneResultTerm|term1:uses1;term2:uses2;term3:uses3;...
 HighestResultLastSearch|term:results
-Position3Bestseller|product:quantity
 TopUseTerm|term:uses
 FirstNonZeroResult|term:results
 TotalUniqueTerms|count
@@ -51,13 +49,12 @@ TotalUniqueTerms|count
 TankSearchCount|X
 ZeroResultsCount|X
 HighestUseTerm|search_term:XX
-Results20to30Term|search_term1:XX1|search_term2:XX2|search_term3:XX3|...
+Results20to30Term|search_term1:XX1;search_term2:XX2;search_term3:XX3;...
 Hits15PlusCount|X
 ID10to15MaxResults|Product Name:XX
 DefaultStoreViewCount|X
-OneResultTerm|search_term1:XX1|search_term2:XX2|search_term3:XX3|...
+OneResultTerm|search_term1:XX1;search_term2:XX2;search_term3:XX3;...
 HighestResultLastSearch|search_term:XX
-Position3Bestseller|Product Name:X
 TopUseTerm|search_term:XX
 FirstNonZeroResult|search_term:X
 TotalUniqueTerms|X
@@ -72,5 +69,5 @@ TotalUniqueTerms|X
 - Navigated between different report views
 - Extracted data from filtered and sorted results
 - Counted records accurately after applying filters
-- Output answer in exact format with 13 data lines
+- Output answer in exact format with 12 data lines
 - Answer wrapped in <answer> tags

--- a/tasks/playwright_webarena/standard/shopping_admin/search_filtering_operations/label.txt
+++ b/tasks/playwright_webarena/standard/shopping_admin/search_filtering_operations/label.txt
@@ -1,13 +1,12 @@
 TankSearchCount|2
 ZeroResultsCount|1
 HighestUseTerm|hollister:19
-Results20to30Term|Antonia Racer Tank:23|tanks:23
+Results20to30Term|Antonia Racer Tank:23;tanks:23
 Hits15PlusCount|1
 ID10to15MaxResults|Antonia Racer Tank:23
 DefaultStoreViewCount|7
-OneResultTerm|hollister:19|WP10:1
+OneResultTerm|hollister:19;WP10:1
 HighestResultLastSearch|Antonia Racer Tank:23
-Position3Bestseller|Sprite Stasis Ball 65 cm:6
 TopUseTerm|hollister:19
 FirstNonZeroResult|WP10:1
 TotalUniqueTerms|7

--- a/tasks/playwright_webarena/standard/shopping_admin/search_filtering_operations/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/search_filtering_operations/verify.py
@@ -1,322 +1,259 @@
-import re
-import json
-import os
+import asyncio
 import sys
+import re
+import os
+import json
+from pathlib import Path
 
 
-def verify(messages):
+def get_model_response():
     """
-    Verify that the agent has successfully performed complex search and filtering operations
-    in the Magento Admin panel and extracted all required information correctly.
-
-    Args:
-        messages: List of message dictionaries containing the conversation
-
-    Returns:
-        Dictionary with 'valid' boolean and 'reason' string
+    Get the model's response from the MCP_MESSAGES environment variable.
+    Returns the last assistant message text.
     """
-
-    # Find the last assistant message with status "completed" and type "message"
-    answer_content = None
-    for message in reversed(messages):
-        if (
-            message.get("role") == "assistant"
-            and message.get("status") == "completed"
-            and message.get("type") == "message"
-            and message.get("content")
-        ):
-            # Extract text from content structure
-            content = message["content"]
-            if isinstance(content, list):
-                for item in content:
-                    if isinstance(item, dict) and item.get("type") == "output_text":
-                        text = item.get("text", "")
-                        # Look for answer tags with case-insensitive search
-                        answer_match = re.search(
-                            r"<answer>(.*?)</answer>", text, re.DOTALL | re.IGNORECASE
-                        )
-                        if answer_match:
-                            answer_content = answer_match.group(1).strip()
-                            break
-            elif isinstance(content, str):
-                # Look for answer tags in string content
-                answer_match = re.search(r"<answer>(.*?)</answer>", content, re.DOTALL | re.IGNORECASE)
-                if answer_match:
-                    answer_content = answer_match.group(1).strip()
-                    break
-
-            if answer_content:
-                break
-
-    if not answer_content:
-        return {"valid": False, "reason": "No answer found in <answer> tags"}
-
-    # Expected format - each line should have a key|value pair
-    expected_keys = [
-        "TankSearchCount",
-        "ZeroResultsCount",
-        "HighestUseTerm",
-        "Results20to30Term",
-        "Hits15PlusCount",
-        "ID10to15MaxResults",
-        "DefaultStoreViewCount",
-        "OneResultTerm",
-        "HighestResultLastSearch",
-        "Position3Bestseller",
-        "TopUseTerm",
-        "FirstNonZeroResult",
-        "TotalUniqueTerms",
-    ]
-
-    # Parse the answer
-    lines = answer_content.strip().split("\n")
-
-    # Check if we have exactly 13 lines
-    if len(lines) != 13:
-        return {"valid": False, "reason": f"Expected 13 data lines, found {len(lines)}"}
-
-    # Parse each line and validate format
-    extracted_data = {}
-    for line in lines:
-        if "|" not in line:
-            return {
-                "valid": False,
-                "reason": f"Invalid format in line: {line}. Expected 'key|value' format",
-            }
-
-        parts = line.split("|", 1)
-        if len(parts) != 2:
-            return {"valid": False, "reason": f"Invalid format in line: {line}"}
-
-        key, value = parts
-        extracted_data[key] = value
-
-    # Check all required keys are present
-    missing_keys = set(expected_keys) - set(extracted_data.keys())
-    if missing_keys:
-        return {
-            "valid": False,
-            "reason": f"Missing required keys: {', '.join(missing_keys)}",
-        }
-
-    # Validate specific data formats and expected values based on the current data
-
-    # 1. TankSearchCount should be a number (2 terms containing 'tank')
-    if not extracted_data["TankSearchCount"].isdigit():
-        return {
-            "valid": False,
-            "reason": f"TankSearchCount should be a number, got: {extracted_data['TankSearchCount']}",
-        }
-
-    # Expected: "Antonia Racer Tank" and "tanks" contain 'tank'
-    if extracted_data["TankSearchCount"] != "2":
-        return {
-            "valid": False,
-            "reason": f"TankSearchCount should be '2', got: {extracted_data['TankSearchCount']}",
-        }
-
-    # 2. ZeroResultsCount should be a number (nike has 0 results)
-    if not extracted_data["ZeroResultsCount"].isdigit():
-        return {
-            "valid": False,
-            "reason": f"ZeroResultsCount should be a number, got: {extracted_data['ZeroResultsCount']}",
-        }
-
-    if extracted_data["ZeroResultsCount"] != "1":
-        return {
-            "valid": False,
-            "reason": f"ZeroResultsCount should be '1', got: {extracted_data['ZeroResultsCount']}",
-        }
-
-    # 3. HighestUseTerm should be in format "term:uses"
-    if ":" not in extracted_data["HighestUseTerm"]:
-        return {
-            "valid": False,
-            "reason": f"HighestUseTerm should be in format 'term:uses', got: {extracted_data['HighestUseTerm']}",
-        }
-
-    # hollister has 19 uses (highest among terms with > 10 uses)
-    if extracted_data["HighestUseTerm"] != "hollister:19":
-        return {
-            "valid": False,
-            "reason": f"HighestUseTerm should be 'hollister:19', got: {extracted_data['HighestUseTerm']}",
-        }
-
-    # 4. Results20to30Term should be in format "term:results"
-    if ":" not in extracted_data["Results20to30Term"]:
-        return {
-            "valid": False,
-            "reason": f"Results20to30Term should be in format 'term:results', got: {extracted_data['Results20to30Term']}",
-        }
-
-    # Both "tanks" and "Antonia Racer Tank" have 23 results (between 20-30)
-    valid_results20to30 = ["tanks:23", "Antonia Racer Tank:23"]
-    # Check if answer contains one of the valid values or both separated by |
-    if not any(
-        val in extracted_data["Results20to30Term"] for val in valid_results20to30
-    ):
-        return {
-            "valid": False,
-            "reason": f"Results20to30Term should contain 'tanks:23' or 'Antonia Racer Tank:23', got: {extracted_data['Results20to30Term']}",
-        }
-
-    # 5. Hits15PlusCount should be a number (only hollister has 19 hits > 15)
-    if not extracted_data["Hits15PlusCount"].isdigit():
-        return {
-            "valid": False,
-            "reason": f"Hits15PlusCount should be a number, got: {extracted_data['Hits15PlusCount']}",
-        }
-
-    if extracted_data["Hits15PlusCount"] != "1":
-        return {
-            "valid": False,
-            "reason": f"Hits15PlusCount should be '1', got: {extracted_data['Hits15PlusCount']}",
-        }
-
-    # 6. ID10to15MaxResults should be in format "term:results"
-    if ":" not in extracted_data["ID10to15MaxResults"]:
-        return {
-            "valid": False,
-            "reason": f"ID10to15MaxResults should be in format 'term:results', got: {extracted_data['ID10to15MaxResults']}",
-        }
-
-    # ID 11 is hollister (1 result), ID 13 is Antonia Racer Tank (23 results)
-    if extracted_data["ID10to15MaxResults"] != "Antonia Racer Tank:23":
-        return {
-            "valid": False,
-            "reason": f"ID10to15MaxResults should be 'Antonia Racer Tank:23', got: {extracted_data['ID10to15MaxResults']}",
-        }
-
-    # 7. DefaultStoreViewCount should be a number (all 7 terms are from Default Store View)
-    if not extracted_data["DefaultStoreViewCount"].isdigit():
-        return {
-            "valid": False,
-            "reason": f"DefaultStoreViewCount should be a number, got: {extracted_data['DefaultStoreViewCount']}",
-        }
-
-    if extracted_data["DefaultStoreViewCount"] != "7":
-        return {
-            "valid": False,
-            "reason": f"DefaultStoreViewCount should be '7', got: {extracted_data['DefaultStoreViewCount']}",
-        }
-
-    # 8. OneResultTerm should be in format "term:uses"
-    if ":" not in extracted_data["OneResultTerm"]:
-        return {
-            "valid": False,
-            "reason": f"OneResultTerm should be in format 'term:uses', got: {extracted_data['OneResultTerm']}",
-        }
-
-    # Both hollister and WP10 have exactly 1 result
-    valid_one_result = ["hollister:19", "WP10:1"]
-    if not any(val in extracted_data["OneResultTerm"] for val in valid_one_result):
-        return {
-            "valid": False,
-            "reason": f"OneResultTerm should contain 'hollister:19' or 'WP10:1', got: {extracted_data['OneResultTerm']}",
-        }
-
-    # 9. HighestResultLastSearch should be in format "term:results"
-    if ":" not in extracted_data["HighestResultLastSearch"]:
-        return {
-            "valid": False,
-            "reason": f"HighestResultLastSearch should be in format 'term:results', got: {extracted_data['HighestResultLastSearch']}",
-        }
-
-    # In Last Search Terms: tanks and Antonia Racer Tank both have 23 results (highest)
-    valid_highest_last = ["tanks:23", "Antonia Racer Tank:23"]
-    if not any(
-        val in extracted_data["HighestResultLastSearch"] for val in valid_highest_last
-    ):
-        return {
-            "valid": False,
-            "reason": f"HighestResultLastSearch should contain 'tanks:23' or 'Antonia Racer Tank:23', got: {extracted_data['HighestResultLastSearch']}",
-        }
-
-    # 10. Position3Bestseller should be in format "product:quantity"
-    if ":" not in extracted_data["Position3Bestseller"]:
-        return {
-            "valid": False,
-            "reason": f"Position3Bestseller should be in format 'product:quantity', got: {extracted_data['Position3Bestseller']}",
-        }
-
-    # Position 3 in Bestsellers is "Sprite Stasis Ball 65 cm" with quantity 6
-    if extracted_data["Position3Bestseller"] != "Sprite Stasis Ball 65 cm:6":
-        return {
-            "valid": False,
-            "reason": f"Position3Bestseller should be 'Sprite Stasis Ball 65 cm:6', got: {extracted_data['Position3Bestseller']}",
-        }
-
-    # 11. TopUseTerm should be in format "term:uses"
-    if ":" not in extracted_data["TopUseTerm"]:
-        return {
-            "valid": False,
-            "reason": f"TopUseTerm should be in format 'term:uses', got: {extracted_data['TopUseTerm']}",
-        }
-
-    # hollister has 19 uses (highest)
-    if extracted_data["TopUseTerm"] != "hollister:19":
-        return {
-            "valid": False,
-            "reason": f"TopUseTerm should be 'hollister:19', got: {extracted_data['TopUseTerm']}",
-        }
-
-    # 12. FirstNonZeroResult should be in format "term:results"
-    if ":" not in extracted_data["FirstNonZeroResult"]:
-        return {
-            "valid": False,
-            "reason": f"FirstNonZeroResult should be in format 'term:results', got: {extracted_data['FirstNonZeroResult']}",
-        }
-
-    # When sorted by results ascending, first non-zero is WP10 (has 1 result)
-    if extracted_data["FirstNonZeroResult"] != "WP10:1":
-        return {
-            "valid": False,
-            "reason": f"FirstNonZeroResult should be 'WP10:1', got: {extracted_data['FirstNonZeroResult']}",
-        }
-
-    # 13. TotalUniqueTerms should be a number
-    if not extracted_data["TotalUniqueTerms"].isdigit():
-        return {
-            "valid": False,
-            "reason": f"TotalUniqueTerms should be a number, got: {extracted_data['TotalUniqueTerms']}",
-        }
-
-    # There are 7 unique search terms in the system
-    if extracted_data["TotalUniqueTerms"] != "7":
-        return {
-            "valid": False,
-            "reason": f"TotalUniqueTerms should be '7', got: {extracted_data['TotalUniqueTerms']}",
-        }
-
-    # All validations passed
-    return {
-        "valid": True,
-        "reason": "All complex search and filtering operations completed successfully",
-    }
-
-
-if __name__ == "__main__":
-    # Load messages from environment variable
     messages_path = os.getenv("MCP_MESSAGES")
+    print(f"MCP_MESSAGES: {messages_path}", file=sys.stderr)
     if not messages_path:
-        print(
-            json.dumps(
-                {"valid": False, "reason": "MCP_MESSAGES environment variable not set"}
-            )
-        )
-        exit(1)
+        print("Warning: MCP_MESSAGES environment variable not set", file=sys.stderr)
+        return None
 
     try:
         with open(messages_path, "r") as f:
             messages = json.load(f)
-    except Exception as e:
-        print(
-            json.dumps({"valid": False, "reason": f"Failed to load messages: {str(e)}"})
-        )
-        exit(1)
 
-    # Run verification
-    result = verify(messages)
-    print(json.dumps(result))
-    # Exit with appropriate code based on verification result
-    sys.exit(0 if result["valid"] else 1)
+        # Find the last assistant message with status='completed', type='message'
+        for message in reversed(messages):
+            if (
+                message.get("role") == "assistant"
+                and message.get("status") == "completed"
+                and message.get("type") == "message"
+            ):
+                content = message.get("content", [])
+                if isinstance(content, list):
+                    for item in content:
+                        if isinstance(item, dict) and item.get("type") in ["text", "output_text"]:
+                            return item.get("text", "")
+                elif isinstance(content, str):
+                    return content
+
+        print("Warning: No assistant response found in messages", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"Error reading messages file: {str(e)}", file=sys.stderr)
+        return None
+
+
+def parse_answer_format(text):
+    """
+    Parse the <answer>...</answer> format from the agent's output.
+    Returns a dictionary with the parsed values.
+    """
+    if not text:
+        print("Error: No text provided to parse", file=sys.stderr)
+        return None
+
+    match = re.search(r"<answer>(.*?)</answer>", text, re.IGNORECASE | re.DOTALL)
+    if not match:
+        print("Error: No <answer>...</answer> tags found in response", file=sys.stderr)
+        return None
+
+    answer_content = match.group(1).strip()
+    if not answer_content:
+        print("Error: Empty answer content", file=sys.stderr)
+        return None
+
+    lines = [line.strip() for line in answer_content.split("\n") if line.strip()]
+
+    if len(lines) != 12:
+        print(f"Error: Expected 12 lines in answer, got {len(lines)}", file=sys.stderr)
+        print(f"Lines found: {lines}", file=sys.stderr)
+        return None
+
+    expected_keys = [
+        "TankSearchCount", "ZeroResultsCount", "HighestUseTerm",
+        "Results20to30Term", "Hits15PlusCount", "ID10to15MaxResults",
+        "DefaultStoreViewCount", "OneResultTerm", "HighestResultLastSearch",
+        "TopUseTerm", "FirstNonZeroResult", "TotalUniqueTerms",
+    ]
+
+    result = {}
+    for line in lines:
+        if "|" not in line:
+            print(f"Error: Line missing '|' separator: {line}", file=sys.stderr)
+            return None
+        parts = line.split("|", 1)
+        if len(parts) != 2:
+            print(f"Error: Invalid line format: {line}", file=sys.stderr)
+            return None
+        key, value = parts[0].strip(), parts[1].strip()
+        if not key or not value:
+            print(f"Error: Empty key or value in line: {line}", file=sys.stderr)
+            return None
+        result[key] = value
+
+    missing_keys = set(expected_keys) - set(result.keys())
+    if missing_keys:
+        print(f"Error: Missing required keys: {missing_keys}", file=sys.stderr)
+        return None
+
+    return result
+
+
+def load_expected_answer(label_path):
+    """
+    Load the expected answer from label.txt file.
+    Returns a dictionary with the expected values.
+
+    Each line is "Key|value..."; split only on the first '|' so values that
+    themselves contain '|' (e.g. "term1:c1|term2:c2") are preserved.
+    """
+    try:
+        with open(label_path, "r") as f:
+            lines = f.read().strip().split("\n")
+
+        expected = {}
+        for line in lines:
+            if "|" in line:
+                key, value = line.split("|", 1)
+                expected[key.strip()] = value.strip()
+
+        return expected
+    except Exception as e:
+        print(f"Error reading label file: {str(e)}", file=sys.stderr)
+        return None
+
+
+def compare_answers(model_answer, expected_answer):
+    """
+    Compare the model's answer with the expected answer.
+    Returns True if all key information matches, False otherwise.
+    """
+    if not model_answer or not expected_answer:
+        return False
+
+    mismatches = []
+    for key, expected_value in expected_answer.items():
+        model_value = model_answer.get(key, "")
+
+        if key in [
+            "TankSearchCount",
+            "ZeroResultsCount",
+            "Hits15PlusCount",
+            "DefaultStoreViewCount",
+            "TotalUniqueTerms",
+        ]:
+            # Numeric counts: compare as int so "04" / "4" / "4.0" don't fail
+            try:
+                if int(float(model_value)) != int(float(expected_value)):
+                    mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+            except ValueError:
+                mismatches.append(f"{key} should be numeric: got '{model_value}'")
+
+        elif key in [
+            "HighestUseTerm",
+            "ID10to15MaxResults",
+            "HighestResultLastSearch",
+            "TopUseTerm",
+            "FirstNonZeroResult",
+        ]:
+            # Single "term:count" — term case-insensitive, count as int
+            if ":" not in expected_value or ":" not in model_value:
+                mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+                continue
+            exp_term, exp_count = expected_value.rsplit(":", 1)
+            mod_term, mod_count = model_value.rsplit(":", 1)
+            if exp_term.strip().lower() != mod_term.strip().lower():
+                mismatches.append(f"{key} term: expected '{exp_term}', got '{mod_term}'")
+            try:
+                if int(exp_count.strip()) != int(mod_count.strip()):
+                    mismatches.append(f"{key} count: expected '{exp_count}', got '{mod_count}'")
+            except ValueError:
+                mismatches.append(f"{key} count should be numeric: got '{mod_count}'")
+
+        elif key in ["Results20to30Term", "OneResultTerm"]:
+            # Multi-entry "term1:count1;term2:count2;..." — order-independent;
+            # term case-insensitive, count as int
+            expected_entries = set()
+            for item in expected_value.split(";"):
+                item = item.strip()
+                if ":" not in item:
+                    continue
+                term, count = item.rsplit(":", 1)
+                expected_entries.add((term.strip().lower(), int(count.strip())))
+            model_entries = set()
+            for item in model_value.split(";"):
+                item = item.strip()
+                if ":" not in item:
+                    mismatches.append(f"{key}: malformed entry '{item}'")
+                    continue
+                term, count = item.rsplit(":", 1)
+                try:
+                    model_entries.add((term.strip().lower(), int(count.strip())))
+                except ValueError:
+                    mismatches.append(f"{key}: non-numeric count in '{item}'")
+            if expected_entries != model_entries:
+                mismatches.append(
+                    f"{key}: expected '{expected_value}', got '{model_value}'"
+                )
+
+        else:
+            # Fallback exact match for any unrecognized key
+            if model_value != expected_value:
+                mismatches.append(f"{key}: expected '{expected_value}', got '{model_value}'")
+
+    if mismatches:
+        print("\n=== Answer Comparison Mismatches ===", file=sys.stderr)
+        for mismatch in mismatches:
+            print(f"✗ {mismatch}", file=sys.stderr)
+        return False
+
+    print("\n=== Answer Comparison ===", file=sys.stderr)
+    print("✓ All key information matches the expected answer", file=sys.stderr)
+    return True
+
+
+async def verify() -> bool:
+    """
+    Verify the search and filtering operations task by comparing the model's
+    answer against the expected label.
+    """
+    label_path = Path(__file__).parent / "label.txt"
+
+    expected_answer = load_expected_answer(label_path)
+    if not expected_answer:
+        print("Error: Could not load expected answer from label.txt", file=sys.stderr)
+        return False
+
+    model_response = get_model_response()
+    if not model_response:
+        print("No model response found", file=sys.stderr)
+        return False
+
+    print("Found model response, parsing answer format...", file=sys.stderr)
+    model_answer = parse_answer_format(model_response)
+    if not model_answer:
+        print("Could not parse answer format from model response", file=sys.stderr)
+        return False
+
+    print("\n=== Model Answer Parsed ===", file=sys.stderr)
+    for key, value in model_answer.items():
+        print(f"{key}: {value}", file=sys.stderr)
+
+    answer_match = compare_answers(model_answer, expected_answer)
+    if not answer_match:
+        print("\nModel answer does not match expected answer", file=sys.stderr)
+        return False
+    print("\n✓ Model answer matches expected answer", file=sys.stderr)
+    return True
+
+
+def main():
+    """
+    Executes the verification process and exits with a status code.
+    """
+    result = asyncio.run(verify())
+    sys.exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/playwright_webarena/standard/shopping_admin/search_filtering_operations/verify.py
+++ b/tasks/playwright_webarena/standard/shopping_admin/search_filtering_operations/verify.py
@@ -43,6 +43,22 @@ def get_model_response():
         return None
 
 
+def normalize_text(text):
+    """
+    Normalize text for comparison by collapsing whitespace.
+    """
+    if not isinstance(text, str):
+        return str(text)
+
+    text = text.replace("‘", "'").replace("’", "'")
+    text = text.replace("“", '"').replace("”", '"')
+
+    # Normalize whitespace
+    text = " ".join(text.split())
+
+    return text.strip()
+
+
 def parse_answer_format(text):
     """
     Parse the <answer>...</answer> format from the agent's output.
@@ -85,7 +101,7 @@ def parse_answer_format(text):
         if len(parts) != 2:
             print(f"Error: Invalid line format: {line}", file=sys.stderr)
             return None
-        key, value = parts[0].strip(), parts[1].strip()
+        key, value = parts[0].strip(), normalize_text(parts[1].strip())
         if not key or not value:
             print(f"Error: Empty key or value in line: {line}", file=sys.stderr)
             return None
@@ -115,7 +131,7 @@ def load_expected_answer(label_path):
         for line in lines:
             if "|" in line:
                 key, value = line.split("|", 1)
-                expected[key.strip()] = value.strip()
+                expected[key.strip()] = normalize_text(value.strip())
 
         return expected
     except Exception as e:


### PR DESCRIPTION
## Summary

Bundle of fixes to standard `playwright_webarena` tasks accumulated on `dlx/verify`. Brings 30 commits worth of verify / task-description tightening to `pin-all-versions`.

Highlights:
- **Tighten verify logic** for 14 standard shopping / shopping_admin tasks and several reddit tasks (advanced_product_analysis, gaming_accessories_analysis, multi_category_budget_analysis, printer_keyboard_search, running_shoes_purchase, health_routine_optimization, holiday_baking_competition, customer_segmentation_setup, fitness_promotion_strategy, marketing_customer_analysis, ny_expansion_analysis, products_sales_analysis, sales_inventory_analysis, search_filtering_operations).
- **Unicode smart-quote normalization** in 21 standard verify scripts so model output containing `’ ‘ ” “` matches ASCII `label.txt` values.
- **Bug: icon-only vote button selector** in `reddit/budget_europe_travel/verify.py` — switched from `button:has-text("Retract upvote")` to `button[title="Retract upvote"]` since Postmill renders the vote button with no text node.
- **Description ↔ label alignment** in `shopping_admin/sales_inventory_analysis/description.md` — Customer Since field now spells out the full Magento timestamp format.
- **Misc**: route `MCP_MESSAGES:` log line to stderr in 9 standard verify scripts; handle `&trade;` HTML entity in fitness Bestseller name; add `gpt-5.5` model entry + `xhigh` reasoning-effort choice in pipeline / model_config.

## Test plan

- [ ] AST-parse every modified verify.py (already validated locally)
- [ ] Re-run failed task traces from `results/pw_debug/` against the updated verifies to confirm previously-incorrect failures now classify correctly
- [ ] Spot-check label.txt comparisons still pass for known-good traces (no false negatives from normalization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)