### PR TITLE
fix: stabilize verification scripts for 5 standard GitHub tasks

### DIFF
--- a/tasks/github/standard/easyr1/qwen3_issue_management/verify.py
+++ b/tasks/github/standard/easyr1/qwen3_issue_management/verify.py
@@ -27,34 +27,26 @@ def _get_github_api(
         return False, None
 
 
-def _search_github_issues(
-    query: str, headers: Dict[str, str]
-) -> Tuple[bool, Optional[List]]:
-    """Search GitHub issues using the search API."""
-    url = f"https://api.github.com/search/issues?q={query}&per_page=100"
-    try:
-        response = requests.get(url, headers=headers)
-        if response.status_code == 200:
-            data = response.json()
-            return True, data.get("items", [])
-        else:
-            print(f"Search API error: {response.status_code}", file=sys.stderr)
-            return False, None
-    except Exception as e:
-        print(f"Search exception: {e}", file=sys.stderr)
-        return False, None
-
-
 def _check_qwen3_issues_reopened(headers: Dict[str, str]) -> Tuple[bool, List]:
     """Check if all Qwen3 issues have been reopened and tagged."""
-    # Search for all issues mentioning qwen3 (both open and closed)
-    github_org = os.environ.get("GITHUB_EVAL_ORG")
-    success, all_qwen3_issues = _search_github_issues(
-        f"repo:{github_org}/EasyR1 qwen3", headers
-    )
+    # /search/issues is unreliable on freshly-imported repos (no index yet) and
+    # rejects unencoded queries. Fetch issues directly and filter client-side.
+    success, issues = _get_github_api("issues?state=all&per_page=100", headers)
+    if not success or issues is None:
+        print("Error: Could not fetch issues for Qwen3 check", file=sys.stderr)
+        return False, []
 
-    if not success or not all_qwen3_issues:
-        print("Error: Could not search for Qwen3 issues", file=sys.stderr)
+    # Exclude the summary issue itself — it mentions qwen3 by design but isn't
+    # one of the reopened issues it describes.
+    all_qwen3_issues = [
+        i for i in issues
+        if i.get("pull_request") is None
+        and i.get("title") != "Reopened Qwen3 Issues Summary"
+        and "qwen3" in ((i.get("title") or "") + " " + (i.get("body") or "")).lower()
+    ]
+
+    if not all_qwen3_issues:
+        print("Error: No Qwen3 issues found", file=sys.stderr)
         return False, []
 
     reopened_issues = []

--- a/tasks/github/standard/harmony/multi_branch_commit_aggregation/description.md
+++ b/tasks/github/standard/harmony/multi_branch_commit_aggregation/description.md
@@ -27,11 +27,13 @@ In the 'history-report-2025' branch, create a file called `BRANCH_COMMITS.json` 
 **Step 3: Create Cross-Branch Analysis**
 Create a file `CROSS_BRANCH_ANALYSIS.md` that contains:
 - A section "## Top Contributors" listing the 3 contributors with the most commits on the main branch, sorted by commit count (format: "github_username: X commits")
+- Use the GitHub username (i.e. `author.login` from the commits API), and include merge commits in the count
+- If there's a tie at the 3rd position, listing either tied contributor is acceptable
 - Must include keywords: "contributors"
 
 **Step 4: Generate Merge Timeline**
 Create a file `MERGE_TIMELINE.txt` that lists the 10 most recent merge commits from the main branch:
-- Format: `DATE | MERGE_COMMIT_MESSAGE | COMMIT_SHA`
+- Format: `DATE | MERGE_COMMIT_MESSAGE | COMMIT_SHA` where DATE is `YYYY-MM-DD` (UTC)
 - List in reverse chronological order (newest first)
 - Only include actual merge commits (commits that have exactly 2 parent commits)
 - Note: While the commit messages reference PR numbers, those PRs no longer exist in the repository

--- a/tasks/github/standard/harmony/multi_branch_commit_aggregation/verify.py
+++ b/tasks/github/standard/harmony/multi_branch_commit_aggregation/verify.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import re
 import requests
 from typing import Dict, Optional, Tuple
 import base64
@@ -195,26 +196,43 @@ def _check_cross_branch_analysis(content: str) -> bool:
         )
         return False
 
-    # Verify the top 3 contributors with correct counts from main branch (order matters)
-    expected_contributors = [
+    # Top 1 and Top 2 are uniquely determined; Top 3 is tied between axion66 and
+    # zhuohan123 (both have 2 commits on main), so accept either.
+    fixed_top = [
         "scott-oai: 35 commits",
         "egorsmkv: 4 commits",
-        "axion66: 2 commits",
     ]
-
-    for contributor in expected_contributors:
-        if contributor not in content:
+    for entry in fixed_top:
+        if entry not in content:
             print(
-                f"Missing or incorrect contributor entry: {contributor}",
+                f"Missing or incorrect contributor entry: {entry}",
                 file=sys.stderr,
             )
             return False
+
+    tied_third = ("axion66: 2 commits", "zhuohan123: 2 commits")
+    if not any(t in content for t in tied_third):
+        print(
+            "Missing tied third contributor (axion66 or zhuohan123 at 2 commits)",
+            file=sys.stderr,
+        )
+        return False
 
     return True
 
 
 def _check_merge_timeline(content: str) -> bool:
     """Verify MERGE_TIMELINE.txt has correct format and expected merge commits."""
+    # Normalize any ISO 8601 timestamps in the DATE column down to YYYY-MM-DD so
+    # that "2025-08-06T23:21:08Z" or "2025-08-06 23:21:08" both compare equal to
+    # the canonical "2025-08-06". This keeps the SHA / message / ordering checks
+    # strict while accepting any reasonable date representation.
+    normalized = re.sub(
+        r"(\d{4}-\d{2}-\d{2})[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?",
+        r"\1",
+        content,
+    )
+
     expected_timeline = [
         "2025-08-06 | Merge pull request #29 from axion66/improve-readme-and-checks | 3efbf742533a375fc148d75513597e139329578b",
         "2025-08-06 | Merge pull request #30 from Yuan-ManX/harmony-format | 9d653a4c7382abc42d115014d195d9354e7ad357",
@@ -228,9 +246,9 @@ def _check_merge_timeline(content: str) -> bool:
         "2025-08-05 | Merge pull request #17 from openai/dev/scl/add-docs-to-cargo | 64bca4cf327ebeafa0bbd0345650d86e2d02142f",
     ]
 
-    # Verify each expected timeline entry exists in the content
+    # Verify each expected timeline entry exists in the normalized content
     for i, expected_line in enumerate(expected_timeline):
-        if expected_line not in content:
+        if expected_line not in normalized:
             print(f"Missing expected timeline entry {i + 1} in MERGE_TIMELINE.txt", file=sys.stderr)
             print(f"Expected: {expected_line}", file=sys.stderr)
             return False

--- a/tasks/github/standard/harmony/release_management_workflow/verify.py
+++ b/tasks/github/standard/harmony/release_management_workflow/verify.py
@@ -134,14 +134,21 @@ def _check_pr_squash_merged(
     if not success or not commit:
         return False
 
-    # For squash and merge, the commit will have exactly one parent
-    # and the commit message typically includes the PR number
+    # Squash and merge produces a single new commit with one parent (the base
+    # branch tip); regular merge produces a commit with two parents. The
+    # message-content check distinguishes squash from rebase: GitHub's squash
+    # commit either auto-appends `(#N)` (when commit_title is left unset) or
+    # carries the agent-supplied commit_title (which in practice mirrors the
+    # PR title). Rebase, by contrast, preserves the original per-commit
+    # messages, which carry neither signal.
     parents = commit.get("parents", [])
     commit_message = commit.get("commit", {}).get("message", "")
+    pr_title = pr.get("title", "")
 
-    # Squash and merge commits have exactly 1 parent (the base branch)
-    # Regular merge commits have 2 parents (base and head branches)
-    if len(parents) == 1 and f"#{pr_number}" in commit_message:
+    if len(parents) == 1 and (
+        f"#{pr_number}" in commit_message
+        or (pr_title and pr_title in commit_message)
+    ):
         return True
 
     return False

--- a/tasks/github/standard/mcpmark-cicd/linting_ci_workflow/description.md
+++ b/tasks/github/standard/mcpmark-cicd/linting_ci_workflow/description.md
@@ -36,7 +36,7 @@ Create the file `.github/workflows/lint.yml` with:
 - Uses ubuntu-latest runner
 - Sets up Node.js version 18 using actions/setup-node
 - Installs dependencies with npm ci
-- Installs ESLint globally
+- Installs ESLint v8 globally (`npm install -g eslint@8`)
 - Runs ESLint on all JavaScript files in src/ directories
 - Fails the workflow if linting errors are found
 

--- a/tasks/github/standard/mcpmark-cicd/linting_ci_workflow/verify.py
+++ b/tasks/github/standard/mcpmark-cicd/linting_ci_workflow/verify.py
@@ -263,22 +263,22 @@ def verify() -> bool:
 
     # First get the commits for this PR
     commits = _get_pr_commits(pr_number, headers, github_org)
-    if len(commits) != 2:
+    if len(commits) < 2:
         print(
-            f"Error: Expected exactly 2 commits, found {len(commits)}", file=sys.stderr
+            f"Error: Expected at least 2 commits, found {len(commits)}", file=sys.stderr
         )
         return False
 
-    print("✓ Found exactly 2 commits as expected")
+    print(f"✓ Found {len(commits)} commits (>= 2 as required)")
 
     # Sort commits chronologically (oldest first)
     commits.sort(key=lambda x: x.get("commit", {}).get("author", {}).get("date", ""))
 
     first_commit_sha = commits[0].get("sha")
-    second_commit_sha = commits[1].get("sha")
+    second_commit_sha = commits[-1].get("sha")
 
     print(f"First commit (should fail): {first_commit_sha[:7]}")
-    print(f"Second commit (should pass): {second_commit_sha[:7]}")
+    print(f"Last commit (should pass): {second_commit_sha[:7]}")
 
     # Wait for workflows on both commits to complete
     print("Waiting for workflow completion on first commit...")
@@ -286,7 +286,7 @@ def verify() -> bool:
     second_commit_runs = []
 
     start_time = time.time()
-    timeout = 90
+    timeout = 300
     no_workflow_check_count = 0
 
     while time.time() - start_time < timeout:

--- a/tasks/github/standard/missing-semester/assign_contributor_labels/verify.py
+++ b/tasks/github/standard/missing-semester/assign_contributor_labels/verify.py
@@ -74,7 +74,7 @@ def verify() -> bool:
         15: ["assigned-anishathalye"],  # Issue #15
         # PRs
         21: ["assigned-anishathalye"],  # PR #21
-        22: ["assigned-anishathalye"],  # PR #22
+        22: ["assigned-jonhoo"],  # PR #22
         23: ["assigned-anishathalye"],  # PR #23
         24: ["assigned-anishathalye"],  # PR #24
     }


### PR DESCRIPTION
#### Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### Description of Change

Fix verification scripts for 5 GitHub tasks that were failing or flaky against valid agent outputs:

- **qwen3_issue_management** (easyr1): Replaced `/search/issues` with `/repos/{org}/{repo}/issues` + client-side filtering — Search returned 422 on unencoded queries and doesn't index freshly-imported repos. Also excluded the summary issue itself from the qwen3 set (it mentions qwen3 by design but isn't one of the reopened issues it describes).
- **assign_contributor_labels** (missing-semester): Corrected PR #22 expected label to `[assigned-jonhoo]` — the pre-existing expected was inconsistent with the rule applied to the other 6 items (jonhoo is mentioned in comments and appears in past 100 commits; victorferreira does not).
- **linting_ci_workflow** (mcpmark-cicd): Relaxed commit-count check from `!= 2` to `< 2` and compared first/last commit, so agents using single-file MCP endpoints aren't penalized for producing 3+ commits in step 5; raised workflow-completion timeout from 90s to 300s for cold GH runners + `npm ci` + global ESLint install; pinned `npm install -g eslint@8` in the description so the agent's v8-format `.eslintrc.json` is actually loaded (v9 would silently ignore it).
- **multi_branch_commit_aggregation** (harmony): Accept either axion66 or zhuohan123 as the tied third contributor (both have 2 commits on main); normalize ISO 8601 timestamps in MERGE_TIMELINE.txt down to `YYYY-MM-DD` so any valid date representation passes; clarified the `author.login` + include-merges counting rule and UTC date format in the description.
- **release_management_workflow** (harmony): Also accept the PR title in squash-merge commit message detection — GitHub's squash-merge produces either auto-appended `(#N)` or the agent-supplied `commit_title` (which typically mirrors the PR title); matching only the `#N` form caused false negatives.

#### Additional Information

- [x] Ran each verify.py locally and confirmed they pass with valid agent outputs