### PR TITLE
docs: update Notion Source Hub link to new published page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ MCPMark provides a reproducible, extensible benchmark for researchers and engine
 
 ## News
 
+- 📣 **27 May** — The previous Notion Source Hub page is deprecated; please use the new link: [MCPMark Source Hub](https://gossamer-sawfish-47c.notion.site/MCPMark-Source-Hub-dc32b7e8cebd82b8959b81ae322df87a).
 - 📌 **21 Jan** — Pinned MCP server versions for reproducible benchmarks: GitHub MCP Server `v0.15.0` (switched to Docker for version control), Notion MCP Server `@1.9.1` (Notion released 2.0 but it has many bugs, not recommended). See [#246](https://github.com/eval-sys/mcpmark/pull/246).
 - 🔥 **13 Dec** — Added auto-compaction support (`--compaction-token`) to summarize long conversations and avoid context overflow during evaluation ([#236](https://github.com/eval-sys/mcpmark/pull/236])).
 - 🏅 **02 Dec** — Evaluated `gemini-3-pro-preview` (thinking: low): **Pass@1 50.6%** ± 2.3% — so close to `gpt-5-high` (51.6%)! Also `deepseek-v3.2-thinking` 36.8% and `deepseek-v3.2-chat` 29.7%

--- a/docs/mcp/notion.md
+++ b/docs/mcp/notion.md
@@ -8,7 +8,7 @@ This guide walks you through preparing your Notion environment for MCPMark and a
 
 1. **Duplicate the MCPMark Source Pages**
    Copy the template database and pages into your workspace from the public template following this tutorial:
-   [Duplicate MCPMark Source](https://painted-tennis-ebc.notion.site/MCPBench-Source-Hub-23181626b6d7805fb3a7d59c63033819).
+   [Duplicate MCPMark Source](https://gossamer-sawfish-47c.notion.site/MCPMark-Source-Hub-dc32b7e8cebd82b8959b81ae322df87a).
 
 2. **Set up the Source and Eval Hub for Environment Isolation**
    - Prepare **two separate Notion pages**:


### PR DESCRIPTION
## Summary
- A user reported the old Notion Source Hub page (`painted-tennis-ebc.notion.site/MCPBench-Source-Hub-...`) is no longer publicly accessible.
- Republished the source hub at a new URL and updated the link in `docs/mcp/notion.md`.
- Added a News entry in `README.md` noting the deprecation and pointing to the new link.

New link: https://gossamer-sawfish-47c.notion.site/MCPMark-Source-Hub-dc32b7e8cebd82b8959b81ae322df87a

Note: only the top-level Source Hub link is updated here. The `stateUrl` entries in `tasks/notion/**/meta.json` reference specific subpages with their own IDs and are not touched by this PR.

## Test plan
- [x] Verified new link returns HTTP 200
- [ ] Reviewer: confirm the new Notion page is publicly viewable

🤖 Generated with [Claude Code](https://claude.com/claude-code)