### PR TITLE
Stabilize standard Notion verify scripts + descriptions

### DIFF
--- a/tasks/notion/standard/company_in_a_box/employee_onboarding/description.md
+++ b/tasks/notion/standard/company_in_a_box/employee_onboarding/description.md
@@ -1,15 +1,18 @@
 Build an integrated **Employee Onboarding** system for the existing **Company In A Box** page.
 
 **Task Requirements:**
-1. Create a new **database** titled **Employee Onboarding Checklist** with the following properties *exactly*:
+
+Under the top-level page **Company In A Box**, create a new child page titled **Onboarding Hub** that contains, in order:
+
+1. An **Employee Onboarding Checklist** database created inline at the top of the page, with the following properties *exactly*:
    • **Employee Name** – title  
    • **Start Date** – date  
    • **Department** – select (options: Product, Marketing, Sales, HR, Engineering)  
 
-   Populate this database with **3** sample new-hire pages covering three different departments. Every property in each entry must be filled.
+   Populate it with **3** sample new-hire pages covering three different departments. Every property in each entry must be filled.
 
-2. Under the top-level page **Company In A Box**, create a new child page titled **Onboarding Hub** containing, in order:
-   1) The **Employee Onboarding Checklist** database embedded at the top.  
-   2) A section headed **Benefits Overview** that includes linked mentions (@-mentions or link-to-page blocks) to **≥ 3** distinct benefit-policy pages from the **Company Wiki** (for example *Benefits policy*, *Vacation Policy*, *Corporate travel*).  
-   3) A section headed **30-Day Timeline** that presents a numbered list with **7** steps covering the first 30 days. **Each step must reference (via @-mention) an existing page or database**.  
-   4) A section headed **Feedback Form** that provides **≥ 3** to-do items for new hires to check off.
+2. A section headed **Benefits Overview** that includes linked mentions (@-mentions or link-to-page blocks) to **≥ 3** distinct benefit-policy pages from the **Company Wiki** (for example *Benefits policy*, *Vacation Policy*, *Corporate travel*).
+
+3. A section headed **30-Day Timeline** that presents a numbered list with **7** steps covering the first 30 days. **Each step must reference (via @-mention) an existing page or database**.
+
+4. A section headed **Feedback Form** that provides **≥ 3** to-do items for new hires to check off.

--- a/tasks/notion/standard/company_in_a_box/quarterly_review_dashboard/description.md
+++ b/tasks/notion/standard/company_in_a_box/quarterly_review_dashboard/description.md
@@ -7,13 +7,14 @@ Create a quarterly business review dashboard in Notion based on the existing **C
    1. A single **callout** block near the top that summarises progress toward the three *Current Goals* shown on the main page:
       • *LATAM expansion*  • *Enterprise push*  • *Employee engagement*  
       (All three phrases must appear in the callout text.)
-   2. Four separate **section headings** (any heading level) – one for each department (**Product**, **Marketing**, **Sales**, **Human Resources**) – placed below the callout.  Under each heading list that department’s objectives in a progress-tracking format (e.g. to-dos, check-box list). Each objective from the **Company Goals** page must appear at least once.
+   2. Four separate **section headings** (any heading level) – one for each department (**Product**, **Marketing**, **Sales**, **Human Resources**) – placed below the callout, each as its own heading block. Under each heading, list that department's objectives as a **to-do checklist**. Each objective from the **Company Goals** page must appear at least once under its owning department's heading.
    3. Add a **database** named **Action Items** with the following properties *exactly*:
       • **Task Name** – title
       • **Department** – select (options: Product, Marketing, Sales, HR)
       • **Priority** – select (options: High, Medium, Low)
       • **Status** – status
-      Populate this database with **≥ 5** action-item pages derived from the departmental objectives, making sure every field in each entry is filled:
-       • **Task Name** & **Department** must correctly correspond to the underlying objective/department.
+      Populate this database with **≥ 5** action-item pages, **each from a different objective**, covering all four departments (at least one entry per department), and making sure every field in each entry is filled:
+       • **Task Name** must be the exact wording of the underlying objective.
+       • **Department** must be the department that owns that objective.
        • **Priority** and **Status** can be any allowed value, but they must **not** be left empty.
 4. Keep the overall visual style consistent with the existing wiki (use headings, dividers, etc.).

--- a/tasks/notion/standard/company_in_a_box/quarterly_review_dashboard/verify.py
+++ b/tasks/notion/standard/company_in_a_box/quarterly_review_dashboard/verify.py
@@ -1,3 +1,4 @@
+import re
 import sys
 from typing import List
 from notion_client import Client
@@ -9,14 +10,48 @@ def _contains_keywords(text: str, keywords: List[str]) -> bool:
     return all(kw.lower() in lowered for kw in keywords)
 
 
+def _norm(text: str) -> str:
+    """Normalize whitespace and case for tolerant string comparison."""
+    return " ".join(text.lower().split())
+
+
 def verify(notion: Client, main_id: str = None) -> bool:
     """Programmatically verify that the dashboard page and its contents meet the
     requirements described in description.md.
     """
     DASHBOARD_TITLE = "Q4 2024 Business Review Dashboard"
     PARENT_PAGE_TITLE = "Company In A Box"
-    CALL_OUT_KEYWORDS = ["latam", "enterprise", "employee engagement"]
-    DEPARTMENTS = ["Product", "Marketing", "Sales", "Human Resources"]
+    CALL_OUT_KEYWORDS = ["latam expansion", "enterprise push", "employee engagement"]
+
+    # Section heading uses "Human Resources"; the database `Department` select
+    # uses the abbreviation "HR" (per description.md). The two sets are kept
+    # separate on purpose.
+    HEADING_DEPT_NAMES = ["Product", "Marketing", "Sales", "Human Resources"]
+    DB_DEPT_NAMES = {"Product", "Marketing", "Sales", "HR"}
+
+    # Objectives sourced from the Company Goals page in the Company In A Box
+    # workspace. Keyed by the database department option name ("HR", not
+    # "Human Resources"), so it can be reused for entry-level checks below.
+    OBJECTIVES_BY_DEPT = {
+        "Product": [
+            "Launch 3 major features",
+            "Expand enterprise offering",
+        ],
+        "Marketing": [
+            "Improve new user retention",
+            "Publish more help content to reduce burden on support",
+        ],
+        "Sales": [
+            "Close 20 SMB deals",
+            "Create strong sales pitch",
+        ],
+        "HR": [
+            "Fill hiring gaps",
+            "Improve the onboarding experience for new hires",
+        ],
+    }
+    ALL_OBJECTIVES = [obj for objs in OBJECTIVES_BY_DEPT.values() for obj in objs]
+
     REQUIRED_DB_PROPERTIES = {
         "Task Name": "title",
         "Department": "select",
@@ -25,12 +60,24 @@ def verify(notion: Client, main_id: str = None) -> bool:
     }
     PRIORITY_OPTIONS = {"High", "Medium", "Low"}
 
-    # 1. Locate the dashboard page
+    # 1. Locate the dashboard page.
+    # `main_id` is the duplicated seed root (Company In A Box). Search inside
+    # its direct children for a child_page titled DASHBOARD_TITLE.
     page_id = None
     if main_id:
-        found_id, obj_type = notion_utils.find_page_or_database_by_id(notion, main_id)
-        if found_id and obj_type == "page":
-            page_id = found_id
+        try:
+            children = notion.blocks.children.list(block_id=main_id).get(
+                "results", []
+            )
+            for block in children:
+                if (
+                    block.get("type") == "child_page"
+                    and block.get("child_page", {}).get("title") == DASHBOARD_TITLE
+                ):
+                    page_id = block["id"]
+                    break
+        except Exception:
+            pass
 
     if not page_id:
         page_id = notion_utils.find_page(notion, DASHBOARD_TITLE)
@@ -39,18 +86,27 @@ def verify(notion: Client, main_id: str = None) -> bool:
         print(f"Error: Page '{DASHBOARD_TITLE}' not found.", file=sys.stderr)
         return False
 
-    # Optional: ensure it is a child of Company In A Box
+    # Ensure the dashboard is a direct child of Company In A Box.
+    # When `main_id` is provided (the harness path), it IS the seed root, so
+    # compare ids directly. Otherwise fall back to a title comparison.
     try:
         page_obj = notion.pages.retrieve(page_id=page_id)
         parent_id = page_obj.get("parent", {}).get("page_id")
-        if parent_id:
+        if main_id:
+            if not parent_id or parent_id.replace("-", "") != main_id.replace("-", ""):
+                print(
+                    f"Error: Dashboard page is not a direct child of '{PARENT_PAGE_TITLE}'.",
+                    file=sys.stderr,
+                )
+                return False
+        elif parent_id:
             parent_page = notion.pages.retrieve(page_id=parent_id)
             parent_title_rt = (
                 parent_page.get("properties", {}).get("title", {}).get("title", [])
             )
-            parent_title = (
-                parent_title_rt[0].get("plain_text") if parent_title_rt else None
-            )
+            parent_title = "".join(
+                rt.get("plain_text", "") for rt in parent_title_rt
+            ) or None
             if parent_title != PARENT_PAGE_TITLE:
                 print(
                     f"Error: Dashboard page is not a direct child of '{PARENT_PAGE_TITLE}'.",
@@ -76,23 +132,75 @@ def verify(notion: Client, main_id: str = None) -> bool:
         )
         return False
 
-    # 3. Verify department section headings
-    found_depts = set()
-    for block in all_blocks:
-        if block.get("type") in {"heading_1", "heading_2", "heading_3"}:
+    # 3. Verify department section headings exist (word-boundary match so
+    # "Productivity" is not accepted in place of "Product"). Each department
+    # must be satisfied by a *distinct* heading block so a single combined
+    # heading like "Product / Marketing / Sales / Human Resources" cannot
+    # cover all four.
+    dept_to_heading_block = {}
+    used_block_ids = set()
+    for dept in HEADING_DEPT_NAMES:
+        pattern = rf"\b{re.escape(dept)}\b"
+        for block in all_blocks:
+            if block.get("type") not in {"heading_1", "heading_2", "heading_3"}:
+                continue
+            if block["id"] in used_block_ids:
+                continue
             heading_text = notion_utils.get_block_plain_text(block)
-            for dept in DEPARTMENTS:
-                if dept.lower() in heading_text.lower():
-                    found_depts.add(dept)
-    if set(DEPARTMENTS) != found_depts:
-        missing = set(DEPARTMENTS) - found_depts
+            if re.search(pattern, heading_text, flags=re.IGNORECASE):
+                dept_to_heading_block[dept] = block["id"]
+                used_block_ids.add(block["id"])
+                break
+    missing_headings = set(HEADING_DEPT_NAMES) - set(dept_to_heading_block)
+    if missing_headings:
         print(
-            f"Error: Missing department headings: {', '.join(missing)}.",
+            f"Error: Missing distinct department headings: {', '.join(sorted(missing_headings))}.",
             file=sys.stderr,
         )
         return False
 
-    # 4. Verify Action Items database exists and has correct schema
+    # 4. Each objective from the Company Goals page must appear verbatim in a
+    # to-do (checkbox) block, and that to-do block must be located between its
+    # owning department's heading and the next department heading (so each
+    # objective lives under the correct section).
+    block_index = {b["id"]: i for i, b in enumerate(all_blocks)}
+    heading_indices = sorted(block_index[bid] for bid in dept_to_heading_block.values())
+
+    def _section_range(dept: str):
+        start = block_index[dept_to_heading_block[dept]]
+        next_starts = [i for i in heading_indices if i > start]
+        end = next_starts[0] if next_starts else len(all_blocks)
+        return start, end
+
+    todo_blocks = [b for b in all_blocks if b.get("type") == "to_do"]
+    todo_norm_by_id = {
+        b["id"]: _norm(notion_utils.get_block_plain_text(b)) for b in todo_blocks
+    }
+
+    HEADING_TO_DB_DEPT = {
+        "Product": "Product",
+        "Marketing": "Marketing",
+        "Sales": "Sales",
+        "Human Resources": "HR",
+    }
+    for heading_dept in HEADING_DEPT_NAMES:
+        db_dept = HEADING_TO_DB_DEPT[heading_dept]
+        start, end = _section_range(heading_dept)
+        section_todo_norms = [
+            todo_norm_by_id[b["id"]]
+            for b in todo_blocks
+            if start < block_index[b["id"]] < end
+        ]
+        for objective in OBJECTIVES_BY_DEPT[db_dept]:
+            norm_obj = _norm(objective)
+            if not any(norm_obj in t for t in section_todo_norms):
+                print(
+                    f"Error: Objective '{objective}' not found in a to-do block under the '{heading_dept}' heading.",
+                    file=sys.stderr,
+                )
+                return False
+
+    # 5. Verify Action Items database exists and has correct schema
     db_id = notion_utils.find_database_in_block(notion, page_id, "Action Items")
     if not db_id:
         print(
@@ -129,17 +237,32 @@ def verify(notion: Client, main_id: str = None) -> bool:
                     file=sys.stderr,
                 )
                 return False
-        # Extra check for Priority options
-        if prop_name == "Priority":
-            options = {opt["name"] for opt in db_props[prop_name]["select"]["options"]}
-            if not PRIORITY_OPTIONS.issubset(options):
-                print(
-                    f"Error: Priority property options must include High/Medium/Low. Current options: {options}",
-                    file=sys.stderr,
-                )
-                return False
 
-    # 5. Verify at least 5 action items exist
+    # Department select options must be exactly the four declared in description.md
+    dept_options = {
+        opt["name"] for opt in db_props["Department"]["select"]["options"]
+    }
+    if dept_options != DB_DEPT_NAMES:
+        print(
+            f"Error: Department property options must be exactly {sorted(DB_DEPT_NAMES)}. "
+            f"Got: {sorted(dept_options)}.",
+            file=sys.stderr,
+        )
+        return False
+
+    # Priority options must be exactly {High, Medium, Low}
+    priority_options = {
+        opt["name"] for opt in db_props["Priority"]["select"]["options"]
+    }
+    if priority_options != PRIORITY_OPTIONS:
+        print(
+            f"Error: Priority property options must be exactly {sorted(PRIORITY_OPTIONS)}. "
+            f"Got: {sorted(priority_options)}.",
+            file=sys.stderr,
+        )
+        return False
+
+    # 6. Verify at least 5 action items exist and content matches description.
     try:
         pages = notion.databases.query(database_id=db_id).get("results", [])
     except Exception as exc:
@@ -150,13 +273,21 @@ def verify(notion: Client, main_id: str = None) -> bool:
         print("Error: Database contains fewer than 5 action items.", file=sys.stderr)
         return False
 
-    # Optional: Verify Department values valid
+    # Build reverse map objective -> department for entry validation
+    objective_to_dept = {
+        objective: dept
+        for dept, objs in OBJECTIVES_BY_DEPT.items()
+        for objective in objs
+    }
+
+    seen_dept_in_entries = set()
+    seen_entry_pairs = set()
     for page in pages:
         props = page.get("properties", {})
 
-        # Task Name must be non-empty
+        # Task Name must contain the verbatim text of one of the underlying objectives.
         title_rt = props.get("Task Name", {}).get("title", [])
-        task_name = title_rt[0].get("plain_text") if title_rt else ""
+        task_name = "".join(rt.get("plain_text", "") for rt in title_rt)
         if not task_name.strip():
             print(
                 f"Error: Action item '{page.get('id')}' is missing a Task Name.",
@@ -164,24 +295,70 @@ def verify(notion: Client, main_id: str = None) -> bool:
             )
             return False
 
-        # Department must be valid
-        dept_select = props.get("Department", {}).get("select", {}).get("name")
-        if not dept_select or dept_select not in DEPARTMENTS:
+        task_name_norm = _norm(task_name)
+        matched_objective = None
+        for objective in ALL_OBJECTIVES:
+            if _norm(objective) in task_name_norm:
+                matched_objective = objective
+                break
+        if not matched_objective:
             print(
-                f"Error: Action item '{page.get('id')}' has invalid or missing Department value.",
+                f"Error: Action item Task Name '{task_name}' does not contain "
+                f"the verbatim text of any Company Goals objective.",
                 file=sys.stderr,
             )
             return False
 
-        # Priority and Status must be set (any value)
+        # Department must match the department that owns the matched objective.
+        dept_select = props.get("Department", {}).get("select", {}).get("name")
+        if not dept_select or dept_select not in DB_DEPT_NAMES:
+            print(
+                f"Error: Action item '{task_name}' has invalid or missing Department value: '{dept_select}'.",
+                file=sys.stderr,
+            )
+            return False
+
+        expected_dept = objective_to_dept[matched_objective]
+        if dept_select != expected_dept:
+            print(
+                f"Error: Action item '{task_name}' has Department='{dept_select}' "
+                f"but objective '{matched_objective}' belongs to '{expected_dept}'.",
+                file=sys.stderr,
+            )
+            return False
+
+        seen_dept_in_entries.add(dept_select)
+        seen_entry_pairs.add((_norm(matched_objective), dept_select))
+
+        # Priority and Status must be set (any allowed value).
         priority_val = props.get("Priority", {}).get("select", {}).get("name")
         status_val = props.get("Status", {}).get("status", {}).get("name")
         if not priority_val or not status_val:
             print(
-                f"Error: Action item '{page.get('id')}' must have both Priority and Status set.",
+                f"Error: Action item '{task_name}' must have both Priority and Status set.",
                 file=sys.stderr,
             )
             return False
+
+    # All four departments must be represented across the entries.
+    missing_depts = DB_DEPT_NAMES - seen_dept_in_entries
+    if missing_depts:
+        print(
+            f"Error: Action items do not cover all four departments. "
+            f"Missing: {', '.join(sorted(missing_depts))}.",
+            file=sys.stderr,
+        )
+        return False
+
+    # Require at least 5 distinct (objective, department) pairs so the entries
+    # genuinely derive from different objectives rather than duplicates.
+    if len(seen_entry_pairs) < 5:
+        print(
+            f"Error: Action items must include at least 5 distinct "
+            f"(objective, department) pairs. Got {len(seen_entry_pairs)}.",
+            file=sys.stderr,
+        )
+        return False
 
     print(
         "Success: Verified Business Review Dashboard, departmental sections, callout, and Action Items database with ≥5 entries."

--- a/tasks/notion/standard/computer_science_student_dashboard/study_session_tracker/description.md
+++ b/tasks/notion/standard/computer_science_student_dashboard/study_session_tracker/description.md
@@ -1,7 +1,7 @@
 Your goal is to create a new study-session entry in the **Computer Science Student Dashboard** page.
 
 1. Locate the ☑️ Habit tracker section of the page.
-2. **Insert a new date section** immediately **after the existing `2022-09-02` to-do items but *before* the divider block** that follows them. Make sure the new date has proper formatting with a date mention and bold styling like the existing dates, and all to-do items should be unchecked initially. The new section should be inserted right after the 2022-09-02 to-do items but before the divider.
+2. **Insert a new date section for `2025-01-29`** immediately **after the existing `2022-09-02` to-do items but *before* the divider block** that follows them. Make sure the new date has proper formatting with a date mention and bold styling like the existing dates, and all to-do items should be unchecked initially. The new section should be inserted right after the 2022-09-02 to-do items but before the divider.
 3. Directly **beneath** this new date mention, add **exactly four unchecked to-do blocks** with the following plain text (including the leading emoji on each line):
    • 🧠 Review algorithms for technical interview
    • 📚 Study database systems chapter 7

--- a/tasks/notion/standard/computer_science_student_dashboard/study_session_tracker/verify.py
+++ b/tasks/notion/standard/computer_science_student_dashboard/study_session_tracker/verify.py
@@ -106,10 +106,19 @@ def verify(notion: Client, main_id: str | None = None) -> bool:
         )
         return False
 
-    # (2) Verify ordering
-    if not (index_previous_date < index_new_date < index_divider_after_previous):
+    # (2) Verify ordering: new date paragraph must come AFTER the last consecutive
+    #     to-do under the 2022-09-02 paragraph and BEFORE the divider that follows.
+    last_previous_todo_idx = index_previous_date
+    walk = index_previous_date + 1
+    while walk < len(all_blocks) and all_blocks[walk].get("type") == "to_do":
+        last_previous_todo_idx = walk
+        walk += 1
+
+    if not (last_previous_todo_idx < index_new_date < index_divider_after_previous):
         print(
-            "Error: The 2025-01-29 section is positioned incorrectly.", file=sys.stderr
+            "Error: The 2025-01-29 section is positioned incorrectly "
+            "(must sit after the existing 2022-09-02 to-do items and before the divider).",
+            file=sys.stderr,
         )
         return False
 
@@ -122,29 +131,42 @@ def verify(notion: Client, main_id: str | None = None) -> bool:
         "⚡ Practice system design problems",
         "🎯 Complete data structures assignment",
     ]
-    expected_todos: Dict[str, bool] = {
-        _normalize_string(t): False for t in expected_texts
-    }
+    expected_set = {_normalize_string(t) for t in expected_texts}
 
-    # Look through the blocks that lie between the new date mention and the divider
-    for block in all_blocks[index_new_date + 1 : index_divider_after_previous]:
+    # The blocks between the new date paragraph and the divider must be EXACTLY
+    # the four expected to-dos, directly beneath the date mention.
+    new_section_blocks = all_blocks[index_new_date + 1 : index_divider_after_previous]
+    if len(new_section_blocks) != 4:
+        print(
+            f"Error: Expected exactly 4 blocks directly beneath the 2025-01-29 date "
+            f"(before the divider), found {len(new_section_blocks)}.",
+            file=sys.stderr,
+        )
+        return False
+
+    found_texts: set[str] = set()
+    for block in new_section_blocks:
         if block.get("type") != "to_do":
-            # Any non to-do block inside this range indicates mis-placement.
-            # We simply ignore it – correctness is determined by presence of required to-dos.
-            continue
-
+            print(
+                f"Error: Block directly beneath the 2025-01-29 date is not a to-do "
+                f"(got type '{block.get('type')}').",
+                file=sys.stderr,
+            )
+            return False
         plain_text = notion_utils.get_block_plain_text(block).strip()
         plain_text_norm = _normalize_string(plain_text)
-        if plain_text_norm in expected_todos:
-            # (3a) Verify the to-do is unchecked
-            if block["to_do"].get("checked", False):
-                print(f"Error: To-do '{plain_text}' is checked.", file=sys.stderr)
-                return False
-            expected_todos[plain_text_norm] = True
+        if block["to_do"].get("checked", False):
+            print(f"Error: To-do '{plain_text}' is checked.", file=sys.stderr)
+            return False
+        found_texts.add(plain_text_norm)
 
-    missing_items = [text for text, found in expected_todos.items() if not found]
+    missing_items = [t for t in expected_set if t not in found_texts]
     if missing_items:
         print(f"Error: Missing to-do items: {missing_items}", file=sys.stderr)
+        return False
+    extra_items = [t for t in found_texts if t not in expected_set]
+    if extra_items:
+        print(f"Error: Unexpected to-do items: {extra_items}", file=sys.stderr)
         return False
 
     # ---------------------------------------------------------------------

--- a/tasks/notion/standard/it_trouble_shooting_hub/verification_expired_update/description.md
+++ b/tasks/notion/standard/it_trouble_shooting_hub/verification_expired_update/description.md
@@ -1,11 +1,11 @@
 **Task Overview**
 
-My IT knowledge base contains pages whose verification status has expired:
+My IT knowledge base contains pages whose verification has lapsed and needs re-verification:
 
 **Task Requirements**
 1. Locate the database named **"IT Homepage"** inside the main page **"It Trouble Shooting Hub"**.
-2. Within that database, find every page (except for **"It Inventory"**) where the **Verification** property state contains `expired`.
-3. For **each** expired page:
+2. Within that database, find every page (except for **"It Inventory"**) where the **Verification** property state is `unverified`.
+3. For **each** such page:
    • Insert a **callout block** at the very top (as the first child block) whose rich-text content is:
      `VERIFICATION EXPIRED - This page needs review and re-verification`
    • Set the callout’s icon to ⚠️.

--- a/tasks/notion/standard/it_trouble_shooting_hub/verification_expired_update/verify.py
+++ b/tasks/notion/standard/it_trouble_shooting_hub/verification_expired_update/verify.py
@@ -11,6 +11,16 @@ REQUEST_TITLE = "Batch Verification Update Required"
 PRIORITY_HIGH = "High"
 STATUS_IN_PROGRESS = "In progress"
 
+# Ground-truth list of pages that were 'expired' in the seed template.
+# We hardcode by title because the live Verification.state drifts (Notion can
+# transition expired -> unverified over time, and editing a page can clear the
+# state), so re-querying it at verify time is unreliable.
+EXPECTED_EXPIRED_TITLES = [
+    "What Is IT in Charge Of",
+    "How to Submit a Ticket",
+    "Security Awareness Guide",
+]
+
 
 def _get_main_page_id(notion: Client, main_id: str | None) -> str | None:
     """Resolve the main page id starting from CLI arg or by title search."""
@@ -29,23 +39,46 @@ def _fetch_database_id(
     return notion_utils.find_database_in_block(notion, parent_page_id, db_title)
 
 
-def _expired_pages(notion: Client, db_id: str) -> list[dict]:
-    """Return list of page objects with Verification.state == 'expired'."""
-    # Query all pages (API max 100 per call). If many pages expected, iterate.
-    results = notion.databases.query(database_id=db_id).get("results", [])
-    expired = []
-    for page in results:
-        verification_prop = page.get("properties", {}).get("Verification", {})
-        state = verification_prop.get("verification", {}).get("state")
-        # Skip the IT Inventory database entry
+def _query_all_pages(notion: Client, db_id: str) -> list[dict]:
+    """Query every page in a database, paginating until exhausted."""
+    pages: list[dict] = []
+    cursor: str | None = None
+    while True:
+        kwargs = {"database_id": db_id, "page_size": 100}
+        if cursor:
+            kwargs["start_cursor"] = cursor
+        resp = notion.databases.query(**kwargs)
+        pages.extend(resp.get("results", []))
+        if not resp.get("has_more"):
+            break
+        cursor = resp.get("next_cursor")
+    return pages
+
+
+def _expected_expired_pages(notion: Client, db_id: str) -> list[dict] | None:
+    """Resolve the seed-defined expired pages by title.
+
+    Returns the list in the same order as EXPECTED_EXPIRED_TITLES, or None
+    if any expected title is missing in the database.
+    """
+    by_title: dict[str, dict] = {}
+    for page in _query_all_pages(notion, db_id):
         title_prop = page.get("properties", {}).get("Page", {}).get("title", [])
         title_text = title_prop[0].get("plain_text") if title_prop else ""
-        if title_text.strip().lower() == "it inventory":
-            continue
+        if title_text:
+            by_title[title_text.strip()] = page
 
-        if state and "expired" in state.lower():
-            expired.append(page)
-    return expired
+    resolved: list[dict] = []
+    for expected in EXPECTED_EXPIRED_TITLES:
+        page = by_title.get(expected)
+        if not page:
+            print(
+                f"Error: Expected expired page '{expected}' not found in IT Homepage.",
+                file=sys.stderr,
+            )
+            return None
+        resolved.append(page)
+    return resolved
 
 
 def _check_callout_present(notion: Client, page_id: str) -> bool:
@@ -68,9 +101,9 @@ def _check_callout_present(notion: Client, page_id: str) -> bool:
     if icon.get("type") != "emoji" or icon.get("emoji") != CALL_OUT_ICON:
         return False
 
-    # Check text content (callout rich text plain text)
-    plain_text = notion_utils.get_block_plain_text(first_block)
-    return CALL_OUT_TEXT in plain_text
+    # Check text content (callout rich text plain text) — exact match after trim
+    plain_text = notion_utils.get_block_plain_text(first_block).strip()
+    return plain_text == CALL_OUT_TEXT
 
 
 def _find_request_page(notion: Client, db_id: str) -> dict | None:
@@ -94,24 +127,64 @@ def _check_request_properties(page: dict) -> bool:
     return priority == PRIORITY_HIGH and status == STATUS_IN_PROGRESS
 
 
-def _request_page_contains_mentions(
+def _request_page_bullets_match(
     notion: Client, request_page_id: str, expected_page_ids: list[str]
 ) -> bool:
-    children = notion.blocks.children.list(block_id=request_page_id, page_size=100).get(
-        "results", []
-    )
+    """Check the IT Request body bullets correspond exactly to the expected pages.
+
+    Strict reading of "each bullet is a mention of the page processed":
+      - bullet count == len(expected_page_ids)
+      - each bullet's rich_text contains exactly one element, of type
+        mention/page
+      - the set of mentioned page ids equals the set of expected page ids
+    """
+    children = notion.blocks.children.list(
+        block_id=request_page_id, page_size=100
+    ).get("results", [])
     bullet_blocks = [b for b in children if b.get("type") == "bulleted_list_item"]
-    mentioned_ids: set[str] = set()
+
+    if len(bullet_blocks) != len(expected_page_ids):
+        print(
+            f"Error: IT Request body has {len(bullet_blocks)} bullets, "
+            f"expected exactly {len(expected_page_ids)}.",
+            file=sys.stderr,
+        )
+        return False
+
+    expected_set = {_normalize_id(pid) for pid in expected_page_ids}
+    mentioned_ids: list[str] = []
     for block in bullet_blocks:
         rich_text = block.get("bulleted_list_item", {}).get("rich_text", [])
-        for rt in rich_text:
-            if rt.get("type") == "mention":
-                mention = rt.get("mention", {})
-                if mention.get("type") == "page":
-                    mentioned_ids.add(mention.get("page", {}).get("id"))
-    if len(mentioned_ids) < len(expected_page_ids):
+        page_mentions = [
+            rt for rt in rich_text
+            if rt.get("type") == "mention"
+            and rt.get("mention", {}).get("type") == "page"
+        ]
+        if len(page_mentions) != 1:
+            print(
+                "Error: each IT Request bullet must contain exactly one page "
+                f"mention; found {len(page_mentions)}.",
+                file=sys.stderr,
+            )
+            return False
+        mentioned_ids.append(
+            _normalize_id(page_mentions[0]["mention"]["page"].get("id", ""))
+        )
+
+    if set(mentioned_ids) != expected_set:
+        print(
+            f"Error: IT Request bullet mentions do not match expected pages.\n"
+            f"  expected: {sorted(expected_set)}\n"
+            f"  got:      {sorted(set(mentioned_ids))}",
+            file=sys.stderr,
+        )
         return False
-    return all(pid in mentioned_ids for pid in expected_page_ids)
+    return True
+
+
+def _normalize_id(pid: str) -> str:
+    """Notion ids may appear with or without dashes; normalise for comparison."""
+    return pid.replace("-", "").lower()
 
 
 def verify(notion: Client, main_id: str | None = None) -> bool:
@@ -132,21 +205,20 @@ def verify(notion: Client, main_id: str | None = None) -> bool:
         )
         return False
 
-    # Identify expired pages
-    expired_pages = _expired_pages(notion, it_home_db_id)
-    if not expired_pages:
-        print(
-            "Failure: No expired pages found; expected at least one for this task.",
-            file=sys.stderr,
-        )
+    # Identify the expected expired pages by hardcoded title (ground truth)
+    expected_pages = _expected_expired_pages(notion, it_home_db_id)
+    if expected_pages is None:
         return False
 
-    # Verify callout on each expired page
-    for pg in expired_pages:
+    # Verify callout on each expected expired page
+    for pg in expected_pages:
         pid = pg["id"]
+        title_prop = pg.get("properties", {}).get("Page", {}).get("title", [])
+        title_text = title_prop[0].get("plain_text") if title_prop else pid
         if not _check_callout_present(notion, pid):
             print(
-                f"Failure: Callout missing or incorrect on page {pid}.", file=sys.stderr
+                f"Failure: Callout missing or incorrect on page '{title_text}'.",
+                file=sys.stderr,
             )
             return False
 
@@ -162,21 +234,11 @@ def verify(notion: Client, main_id: str | None = None) -> bool:
         print("Failure: Priority or Status incorrect on IT Request.", file=sys.stderr)
         return False
 
-    # Verify bullet list in IT Request body
-    expired_titles = []
-    for p in expired_pages:
-        title_prop = p.get("properties", {}).get("Page", {}).get("title", [])
-        title_text = title_prop[0].get("plain_text") if title_prop else None
-        if title_text:
-            expired_titles.append(title_text)
-    expected_page_ids = [p["id"] for p in expired_pages]
-    if not _request_page_contains_mentions(
+    # Verify bullet list in IT Request body matches the expected pages exactly
+    expected_page_ids = [p["id"] for p in expected_pages]
+    if not _request_page_bullets_match(
         notion, request_page["id"], expected_page_ids
     ):
-        print(
-            "Failure: IT Request body does not contain mentions for all affected pages.",
-            file=sys.stderr,
-        )
         return False
 
     print("Success: All verification checks passed.")

--- a/tasks/notion/standard/japan_travel_planner/daily_itinerary_overview/verify.py
+++ b/tasks/notion/standard/japan_travel_planner/daily_itinerary_overview/verify.py
@@ -4,7 +4,17 @@ from notion_client import Client
 from tasks.utils import notion_utils
 
 
-def verify_todo_database_correspondence(all_blocks, activities_by_day, _):
+def _normalize_apos(s: str) -> str:
+    """Normalise curly apostrophes (U+2018, U+2019) to straight ones for comparison.
+
+    The seed Travel Itinerary database uses a curly apostrophe in entries like
+    'Rikuro's Namba Main Branch'. Agents that retype the name with a straight
+    apostrophe would otherwise fail substring matching here.
+    """
+    return s.replace("’", "'").replace("‘", "'")
+
+
+def verify_todo_database_correspondence(all_blocks, activities_by_day, visited_count):
     """
     Verify that to-do items in the overview page correspond exactly to database activities.
     """
@@ -59,12 +69,15 @@ def verify_todo_database_correspondence(all_blocks, activities_by_day, _):
             if db_activity["city"]:
                 expected_format += f" - {db_activity['city']}"
 
-            # Find matching to-do item
+            # Find matching to-do item (apostrophe-normalised)
+            expected_format_norm = _normalize_apos(expected_format)
+            db_name_norm = _normalize_apos(db_activity["name"])
             matching_todo = None
             for todo in page_todos:
+                todo_text_norm = _normalize_apos(todo["text"])
                 if (
-                    expected_format in todo["text"]
-                    or db_activity["name"] in todo["text"]
+                    expected_format_norm in todo_text_norm
+                    or db_name_norm in todo_text_norm
                 ):
                     matching_todo = todo
                     break
@@ -86,18 +99,22 @@ def verify_todo_database_correspondence(all_blocks, activities_by_day, _):
                 )
                 return False
 
-    # Verify summary count matches checked to-dos
+    # Verify summary count matches the database's true visited count
+    expected_summary = (
+        f"Total activities visited (from Day 1 to Day 3): {visited_count}"
+    )
     for block in all_blocks:
         if block.get("type") == "paragraph":
             block_text = notion_utils.get_block_plain_text(block)
-            if "Total activities visited (from Day 1 to Day 3): 8" in block_text:
+            if expected_summary in block_text:
                 print(
-                    f"Success: Daily Itinerary Overview page created with correct structure. All {checked_todos_count} visited activities match database."
+                    f"Success: Daily Itinerary Overview page created with correct structure. All {visited_count} visited activities match database."
                 )
                 return True
 
     print(
-        f"Error: Summary shows incorrect visited activity count. Expected: {checked_todos_count} (based on checked to-do items)",
+        f"Error: Summary does not show the expected count {visited_count}. "
+        f"Expected line containing: {expected_summary!r}",
         file=sys.stderr,
     )
     return False
@@ -107,7 +124,11 @@ def verify(notion: Client, main_id: str = None) -> bool:
     """
     Verifies that the Daily Itinerary Overview page has been created correctly.
     """
-    # Find the main Japan Travel Planner page
+    # Find the main Japan Travel Planner page.
+    # If main_id is supplied (the normal harness path) we MUST resolve it
+    # successfully; falling back to a global title search in that case can
+    # silently pick up a different copy of the page (e.g. another task's GT).
+    # The title fallback is only used when main_id was not supplied at all.
     page_id = None
     if main_id:
         found_id, object_type = notion_utils.find_page_or_database_by_id(
@@ -115,9 +136,15 @@ def verify(notion: Client, main_id: str = None) -> bool:
         )
         if found_id and object_type == "page":
             page_id = found_id
-
-    if not page_id:
+        else:
+            print(
+                f"Error: Could not resolve main_id {main_id!r} to an accessible page.",
+                file=sys.stderr,
+            )
+            return False
+    else:
         page_id = notion_utils.find_page(notion, "Japan Travel Planner")
+
     if not page_id:
         print("Error: Main 'Japan Travel Planner' page not found.", file=sys.stderr)
         return False
@@ -137,19 +164,6 @@ def verify(notion: Client, main_id: str = None) -> bool:
             if parent.get("type") == "page_id" and parent.get("page_id") == page_id:
                 overview_page_id = result["id"]
                 break
-
-        if not overview_page_id:
-            # Alternative method: check page title directly
-            for result in response.get("results", []):
-                title_list = (
-                    result.get("properties", {}).get("title", {}).get("title", [])
-                )
-                for title_obj in title_list:
-                    if "Daily Itinerary Overview" in title_obj.get("plain_text", ""):
-                        overview_page_id = result["id"]
-                        break
-                if overview_page_id:
-                    break
 
     except Exception as e:
         print(
@@ -268,7 +282,6 @@ def verify(notion: Client, main_id: str = None) -> bool:
 
             # Organize database activities by day
             activities_by_day = {"Day 1": [], "Day 2": [], "Day 3": []}
-            visited_count = 0
 
             for result in db_activities:
                 properties = result.get("properties", {})
@@ -299,7 +312,6 @@ def verify(notion: Client, main_id: str = None) -> bool:
                     elif prop_type == "checkbox":
                         if prop_value.get("checkbox"):
                             activity_info["visited"] = True
-                            visited_count += 1
 
                     # Get day info
                     elif "day" in prop_name.lower() and prop_type in [
@@ -318,6 +330,14 @@ def verify(notion: Client, main_id: str = None) -> bool:
                 # Add to appropriate day if day is specified
                 if activity_info["day"] and activity_info["name"]:
                     activities_by_day[activity_info["day"]].append(activity_info)
+
+            # Visited count is restricted to Day 1-3, matching the summary text
+            visited_count = sum(
+                1
+                for day_acts in activities_by_day.values()
+                for a in day_acts
+                if a["visited"]
+            )
 
             # Now verify to-do items match database activities
             return verify_todo_database_correspondence(

--- a/tasks/notion/standard/japan_travel_planner/packing_progress_summary/description.md
+++ b/tasks/notion/standard/japan_travel_planner/packing_progress_summary/description.md
@@ -1,10 +1,10 @@
 I'm preparing for my Japan trip and need to organize my packing list. Please help me:
 
 **Step 1: Update Items in the Packing List Database**
-In the Clothes category, all items have already been packed except for the hat After this, check the `SIM Card` entry and the `Wallet` entry.
+In the Clothes category, mark all items as packed except for the hat. After this, mark the `SIM Card` entry and the `Wallet` entry as packed.
 
 **Step 2: Create Packing Progress Summary**
-After adding the items, create a new section in the main Japan Travel Planner page immediately after the "Packing List 💼" heading. This section should contain:
+After updating the items, create a new section in the main Japan Travel Planner page immediately after the "Packing List 💼" heading. This section should contain:
 
 1. A paragraph block with the bold text "**Packing Progress Summary**"
 2. Followed by bullet list items showing statistics for each category in the format:

--- a/tasks/notion/standard/japan_travel_planner/restaurant_expenses_sync/verify.py
+++ b/tasks/notion/standard/japan_travel_planner/restaurant_expenses_sync/verify.py
@@ -3,6 +3,10 @@ from notion_client import Client
 from tasks.utils import notion_utils
 
 
+def _norm(s: str) -> str:
+    return s.replace("’", "'").replace(" ", " ")
+
+
 def verify(notion: Client, main_id: str = None) -> bool:
     """
     Verifies that restaurants from Day 1 of Travel Itinerary have corresponding expense entries.
@@ -125,7 +129,7 @@ def verify(notion: Client, main_id: str = None) -> bool:
             expense_text = "".join(
                 t.get("plain_text", "") for t in expense_prop.get("title", [])
             )
-            if expense_text.strip() != restaurant_name:
+            if _norm(expense_text.strip()) != _norm(restaurant_name):
                 continue
 
             # Check Date
@@ -152,9 +156,7 @@ def verify(notion: Client, main_id: str = None) -> bool:
                 comment_text = "".join(
                     t.get("plain_text", "") for t in comment_prop.get("rich_text", [])
                 )
-                if comment_text.strip().replace(
-                    "\u202f", " "
-                ) != expected_description.replace("\u202f", " "):
+                if _norm(comment_text.strip()) != _norm(expected_description):
                     continue
 
             found_matching_expense = True

--- a/tasks/notion/standard/online_resume/layout_adjustment/verify.py
+++ b/tasks/notion/standard/online_resume/layout_adjustment/verify.py
@@ -109,63 +109,53 @@ def verify(notion: Client, main_id: str = None) -> bool:
         print("Error: Languages heading not found in left column.", file=sys.stderr)
         return False
     
-    # Look for Skills heading after Languages
+    # Look for Skills heading after Languages (any heading level is fine).
+    heading_types = ("heading_1", "heading_2", "heading_3")
+    skill_block_types = ("paragraph", "bulleted_list_item", "numbered_list_item")
     for i in range(languages_index + 1, len(left_column_blocks)):
         left_block = left_column_blocks[i]
-        
+
         if (
-            left_block.get("type") == "heading_2"
+            left_block.get("type") in heading_types
             and "Skills" in notion_utils.get_block_plain_text(left_block)
         ):
             skills_section_found = True
-            
-            # Check divider after Skills heading
-            if i + 1 < len(left_column_blocks):
-                next_block = left_column_blocks[i + 1]
-                if next_block.get("type") != "divider":
+
+            # Collect skill rows directly after the Skills heading.
+            # Dividers, empty blocks, and other non-skill blocks are skipped;
+            # we stop only when we hit the next section heading.
+            for j in range(i + 1, len(left_column_blocks)):
+                skill_block = left_column_blocks[j]
+                block_type = skill_block.get("type")
+
+                if block_type in heading_types:
+                    break
+                if block_type not in skill_block_types:
+                    continue
+
+                skill_text = notion_utils.get_block_plain_text(skill_block)
+                if not skill_text or not skill_text.strip():
+                    continue
+
+                # Check icon format
+                if skill_text.startswith("✨✨"):
+                    skills_with_double_sparkles.append(skill_text)
+                elif skill_text.startswith("✨"):
+                    skills_with_single_sparkle.append(skill_text)
+                else:
                     print(
-                        "Error: Divider not found after Skills heading.",
+                        f"Error: Skill '{skill_text}' doesn't start with sparkle icon.",
                         file=sys.stderr,
                     )
                     return False
-            
-            # Collect skills after divider
-            for j in range(i + 2, len(left_column_blocks)):
-                skill_block = left_column_blocks[j]
-                if skill_block.get("type") == "paragraph":
-                    skill_text = notion_utils.get_block_plain_text(skill_block)
-                    if skill_text and skill_text.strip():  # Check for non-empty text
-                        # Check if text is bold
-                        rich_text = skill_block.get("paragraph", {}).get("rich_text", [])
-                        if rich_text and not rich_text[0].get("annotations", {}).get("bold"):
-                            print(
-                                f"Error: Skill '{skill_text}' is not bold.",
-                                file=sys.stderr,
-                            )
-                            return False
-                        
-                        # Check icon format
-                        if skill_text.startswith("✨✨"):
-                            skills_with_double_sparkles.append(skill_text)
-                        elif skill_text.startswith("✨"):
-                            skills_with_single_sparkle.append(skill_text)
-                        else:
-                            print(
-                                f"Error: Skill '{skill_text}' doesn't start with sparkle icon.",
-                                file=sys.stderr,
-                            )
-                            return False
-                        
-                        # Check format includes type in parentheses
-                        if "(" not in skill_text or ")" not in skill_text:
-                            print(
-                                f"Error: Skill '{skill_text}' doesn't include type in parentheses.",
-                                file=sys.stderr,
-                            )
-                            return False
-                elif skill_block.get("type") in ["heading_1", "heading_2", "heading_3"]:
-                    # Stop when we reach another section
-                    break
+
+                # Check format includes type in parentheses
+                if "(" not in skill_text or ")" not in skill_text:
+                    print(
+                        f"Error: Skill '{skill_text}' doesn't include type in parentheses.",
+                        file=sys.stderr,
+                    )
+                    return False
             break
 
     if not skills_section_found:

--- a/tasks/notion/standard/online_resume/work_history_addition/description.md
+++ b/tasks/notion/standard/online_resume/work_history_addition/description.md
@@ -1,9 +1,15 @@
 Hi! I realized I forgot to include one work experience on my resume page titled "Online Resume." Could you please help me add it to the "Work History" section?
 
-The position is "Research Assistant," and it took place from January to August 2023. The description should be: "Assisted in conducting user experience research projects at my bachelor’s program, supporting data collection, analyzing user feedback, and preparing research reports. Developed strong skills in research methodologies and improved collaboration with interdisciplinary teams."
+The position is "Research Assistant," and it took place from January to August 2023. The description should be: "Assisted in conducting user experience research projects at my bachelor's program, supporting data collection, analyzing user feedback, and preparing research reports. Developed strong skills in research methodologies and improved collaboration with interdisciplinary teams."
 
-For the image or logo, please use the one from the "Education" section (my bachelor school) to keep everything consistent.
+Since this is my most recent role, please put it as the **first** entry under Work History (above UI Design Internship).
 
-Also, please make sure that the formatting — including font style, size, and layout — matches the existing entries in the Work History section so it looks seamless.
+Please make sure that the formatting — including font style, size, and layout — matches the existing entries in the Work History section so it looks seamless.
+
+While you're at it, could you also:
+
+1. Update the summary callout near the top of the page so it mentions my new research experience (just weave the word "research" into the existing summary, keep it short — don't rewrite the whole thing).
+
+2. Add a new entry to my Skills database titled "Research Methodologies" with a Skill Level of 0.7.
 
 Thank you!

--- a/tasks/notion/standard/online_resume/work_history_addition/verify.py
+++ b/tasks/notion/standard/online_resume/work_history_addition/verify.py
@@ -2,186 +2,337 @@ import sys
 from notion_client import Client
 from tasks.utils import notion_utils
 
+EXPECTED_TITLE = "Research Assistant"
+EXPECTED_DATE = "January - August 2023"
+EXPECTED_DESCRIPTION = (
+    "Assisted in conducting user experience research projects at my bachelor's program, "
+    "supporting data collection, analyzing user feedback, and preparing research reports. "
+    "Developed strong skills in research methodologies and improved collaboration with "
+    "interdisciplinary teams."
+)
+EXPECTED_SKILL_NAME = "Research Methodologies"
+EXPECTED_SKILL_LEVEL = 0.7
+SUMMARY_KEYWORD = "research"
+SUMMARY_PRESERVED_TOKEN = "Recent graduate"
 
-def verify(notion: Client, main_id: str = None) -> bool:
-    """
-    Verifies that the new work history entry for 'Research Assistant' has been added correctly.
-    """
-    page_id = None
+
+def _list_children(notion: Client, parent_id: str) -> list[dict]:
+    out: list[dict] = []
+    cursor: str | None = None
+    while True:
+        kwargs = {"block_id": parent_id, "page_size": 100}
+        if cursor:
+            kwargs["start_cursor"] = cursor
+        resp = notion.blocks.children.list(**kwargs)
+        out.extend(resp.get("results", []))
+        if not resp.get("has_more"):
+            break
+        cursor = resp.get("next_cursor")
+    return out
+
+
+def _annotations(block: dict) -> dict:
+    block_type = block.get("type")
+    if not block_type:
+        return {}
+    rich_text = block.get(block_type, {}).get("rich_text", [])
+    if not rich_text:
+        return {}
+    return rich_text[0].get("annotations", {})
+
+
+def _check_first_work_entry(notion: Client, page_id: str) -> bool:
+    all_blocks = notion_utils.get_all_blocks_recursively(notion, page_id)
+
+    wh_block = None
+    edu_block = None
+    for b in all_blocks:
+        if b.get("type") != "heading_1":
+            continue
+        text = notion_utils.get_block_plain_text(b).strip()
+        if text == "Work History" and wh_block is None:
+            wh_block = b
+        elif text == "Education" and edu_block is None:
+            edu_block = b
+
+    if not wh_block or not edu_block:
+        print(
+            "Error: Could not locate both 'Work History' and 'Education' headings.",
+            file=sys.stderr,
+        )
+        return False
+
+    wh_parent_id = wh_block.get("parent", {}).get("block_id")
+    edu_parent_id = edu_block.get("parent", {}).get("block_id")
+    if not wh_parent_id or wh_parent_id != edu_parent_id:
+        print(
+            "Error: 'Work History' and 'Education' headings are not siblings under the "
+            "same parent block.",
+            file=sys.stderr,
+        )
+        return False
+
+    siblings = _list_children(notion, wh_parent_id)
+    wh_idx = next(
+        (i for i, b in enumerate(siblings) if b.get("id") == wh_block["id"]), -1
+    )
+    edu_idx = next(
+        (i for i, b in enumerate(siblings) if b.get("id") == edu_block["id"]), -1
+    )
+    if wh_idx < 0 or edu_idx < 0 or edu_idx <= wh_idx:
+        print(
+            "Error: Could not order 'Work History' before 'Education' in their parent.",
+            file=sys.stderr,
+        )
+        return False
+
+    first_column_list = None
+    for i in range(wh_idx + 1, edu_idx):
+        if siblings[i].get("type") == "column_list":
+            first_column_list = siblings[i]
+            break
+
+    if not first_column_list:
+        print(
+            "Error: No column_list found between 'Work History' and 'Education'.",
+            file=sys.stderr,
+        )
+        return False
+
+    columns = _list_children(notion, first_column_list["id"])
+    image_column = None
+    text_column = None
+    for col in columns:
+        if col.get("type") != "column":
+            continue
+        ratio = col.get("column", {}).get("width_ratio")
+        if ratio == 0.125 and image_column is None:
+            image_column = col
+        elif ratio == 0.875 and text_column is None:
+            text_column = col
+
+    if not image_column or not text_column:
+        print(
+            "Error: First Work History column_list does not have the expected "
+            "width_ratios (0.125 / 0.875).",
+            file=sys.stderr,
+        )
+        return False
+
+    text_blocks = _list_children(notion, text_column["id"])
+    paragraphs = [
+        b
+        for b in text_blocks
+        if b.get("type") == "paragraph"
+        and notion_utils.get_block_plain_text(b).strip()
+    ]
+    if len(paragraphs) < 3:
+        print(
+            f"Error: First entry's text column has fewer than 3 non-empty "
+            f"paragraphs (got {len(paragraphs)}).",
+            file=sys.stderr,
+        )
+        return False
+
+    title_block, date_block, description_block = paragraphs[0], paragraphs[1], paragraphs[2]
+
+    title_text = notion_utils.get_block_plain_text(title_block).strip()
+    if title_text != EXPECTED_TITLE:
+        print(
+            f"Error: First Work History entry title is {title_text!r}, expected "
+            f"{EXPECTED_TITLE!r}. The Research Assistant entry must be the FIRST "
+            f"entry under Work History (above UI Design Internship).",
+            file=sys.stderr,
+        )
+        return False
+    if not _annotations(title_block).get("bold"):
+        print("Error: Title is not bold.", file=sys.stderr)
+        return False
+
+    date_text = notion_utils.get_block_plain_text(date_block).strip()
+    if date_text != EXPECTED_DATE:
+        print(
+            f"Error: Date paragraph is {date_text!r}, expected {EXPECTED_DATE!r}.",
+            file=sys.stderr,
+        )
+        return False
+    date_annot = _annotations(date_block)
+    if not date_annot.get("italic"):
+        print(
+            f"Error: Date should be italic (annotations: {date_annot}).",
+            file=sys.stderr,
+        )
+        return False
+    if date_annot.get("color") != "gray":
+        print(
+            f"Error: Date color should be 'gray' (got {date_annot.get('color')!r}).",
+            file=sys.stderr,
+        )
+        return False
+
+    description_text = notion_utils.get_block_plain_text(description_block).strip()
+    if description_text != EXPECTED_DESCRIPTION:
+        print(
+            "Error: Description text mismatch.\n"
+            f"  expected: {EXPECTED_DESCRIPTION!r}\n"
+            f"  got:      {description_text!r}",
+            file=sys.stderr,
+        )
+        return False
+    desc_annot = _annotations(description_block)
+    if desc_annot.get("bold") or desc_annot.get("italic"):
+        print(
+            f"Error: Description should not be bold or italic (got {desc_annot}).",
+            file=sys.stderr,
+        )
+        return False
+    if desc_annot.get("color") not in (None, "default"):
+        print(
+            f"Error: Description color should be 'default' (got "
+            f"{desc_annot.get('color')!r}).",
+            file=sys.stderr,
+        )
+        return False
+
+    return True
+
+
+def _check_summary_callout(notion: Client, page_id: str) -> bool:
+    all_blocks = notion_utils.get_all_blocks_recursively(notion, page_id)
+
+    work_history_idx = -1
+    for i, b in enumerate(all_blocks):
+        if (
+            b.get("type") == "heading_1"
+            and notion_utils.get_block_plain_text(b).strip() == "Work History"
+        ):
+            work_history_idx = i
+            break
+    if work_history_idx < 0:
+        print(
+            "Error: 'Work History' heading not found while looking for summary callout.",
+            file=sys.stderr,
+        )
+        return False
+
+    callouts = [
+        b for b in all_blocks[:work_history_idx] if b.get("type") == "callout"
+    ]
+    if not callouts:
+        print(
+            "Error: No callout block found above the 'Work History' heading.",
+            file=sys.stderr,
+        )
+        return False
+
+    for callout in callouts:
+        text = notion_utils.get_block_plain_text(callout)
+        if SUMMARY_KEYWORD in text.lower() and SUMMARY_PRESERVED_TOKEN in text:
+            return True
+
+    print(
+        f"Error: No callout above 'Work History' contains both the new keyword "
+        f"{SUMMARY_KEYWORD!r} (case-insensitive) and the original phrase "
+        f"{SUMMARY_PRESERVED_TOKEN!r}. The summary should be lightly edited, "
+        f"not rewritten.",
+        file=sys.stderr,
+    )
+    for callout in callouts:
+        snippet = notion_utils.get_block_plain_text(callout)[:200]
+        print(f"  callout text: {snippet!r}", file=sys.stderr)
+    return False
+
+
+def _check_skills_database(notion: Client, page_id: str) -> bool:
+    all_blocks = notion_utils.get_all_blocks_recursively(notion, page_id)
+    skills_db_id = None
+    for b in all_blocks:
+        if b.get("type") == "child_database":
+            title = b.get("child_database", {}).get("title", "")
+            if title == "Skills":
+                skills_db_id = b["id"]
+                break
+
+    if not skills_db_id:
+        print("Error: 'Skills' child database not found on the page.", file=sys.stderr)
+        return False
+
+    rows: list[dict] = []
+    cursor: str | None = None
+    while True:
+        kwargs = {"database_id": skills_db_id, "page_size": 100}
+        if cursor:
+            kwargs["start_cursor"] = cursor
+        resp = notion.databases.query(**kwargs)
+        rows.extend(resp.get("results", []))
+        if not resp.get("has_more"):
+            break
+        cursor = resp.get("next_cursor")
+
+    for row in rows:
+        props = row.get("properties", {})
+        title_prop = props.get("Skill", {}).get("title", [])
+        title_text = "".join(rt.get("plain_text", "") for rt in title_prop).strip()
+        if title_text != EXPECTED_SKILL_NAME:
+            continue
+        level = props.get("Skill Level", {}).get("number")
+        if level == EXPECTED_SKILL_LEVEL:
+            return True
+        print(
+            f"Error: Skills entry {EXPECTED_SKILL_NAME!r} has Skill Level={level!r}, "
+            f"expected {EXPECTED_SKILL_LEVEL}.",
+            file=sys.stderr,
+        )
+        return False
+
+    print(
+        f"Error: Skills database has no entry titled {EXPECTED_SKILL_NAME!r}.",
+        file=sys.stderr,
+    )
+    return False
+
+
+def verify(notion: Client, main_id: str | None = None) -> bool:
+    page_id: str | None = None
     if main_id:
         found_id, object_type = notion_utils.find_page_or_database_by_id(
             notion, main_id
         )
         if found_id and object_type == "page":
             page_id = found_id
-
-    if not page_id:
+        else:
+            print(
+                f"Error: Could not resolve main_id {main_id!r} to an accessible page.",
+                file=sys.stderr,
+            )
+            return False
+    else:
         page_id = notion_utils.find_page(notion, "Online Resume")
+
     if not page_id:
         print("Error: Page 'Online Resume' not found.", file=sys.stderr)
         return False
 
-    all_blocks = notion_utils.get_all_blocks_recursively(notion, page_id)
-
-    def find_image_url_under_heading(blocks, heading_text, notion_client):
-        heading_index = -1
-        for i, block in enumerate(blocks):
-            block_type = block.get("type")
-            if block_type == "heading_1":
-                if heading_text in notion_utils.get_block_plain_text(block):
-                    heading_index = i
-                    break
-
-        if heading_index == -1:
-            return None
-
-        for i in range(heading_index + 1, len(blocks)):
-            block = blocks[i]
-            if block.get("type") in ["heading_1", "heading_2", "heading_3"]:
-                break
-            if block.get("type") == "image" and block.get("image", {}).get("file"):
-                return block.get("image", {}).get("file", {}).get("url")
-            if block.get("type") == "column_list":
-                column_list_id = block["id"]
-                columns = notion_utils.get_all_blocks_recursively(
-                    notion_client, column_list_id
-                )
-                for column in columns:
-                    if column.get("type") == "column":
-                        column_id = column["id"]
-                        column_blocks = notion_utils.get_all_blocks_recursively(
-                            notion_client, column_id
-                        )
-                        for inner_block in column_blocks:
-                            if inner_block.get("type") == "image" and inner_block.get(
-                                "image", {}
-                            ).get("file"):
-                                return (
-                                    inner_block.get("image", {})
-                                    .get("file", {})
-                                    .get("url")
-                                )
-        return None
-
-    def get_block_annotations(block):
-        block_type = block.get("type")
-        if not block_type:
-            return {}
-        block_content = block.get(block_type)
-        if not block_content:
-            return {}
-        rich_text_list = block_content.get("rich_text", [])
-        if not rich_text_list:
-            return {}
-        return rich_text_list[0].get("annotations", {})
-
-    education_image_url = find_image_url_under_heading(all_blocks, "Education", notion)
-    if not education_image_url:
-        print(
-            "Error: Could not find the image in the 'Education' section.",
-            file=sys.stderr,
-        )
+    if not _check_first_work_entry(notion, page_id):
+        return False
+    if not _check_summary_callout(notion, page_id):
+        return False
+    if not _check_skills_database(notion, page_id):
         return False
 
-    heading_text = "Work History"
-    heading_index = -1
-    for i, block in enumerate(all_blocks):
-        if block.get(
-            "type"
-        ) == "heading_1" and heading_text in notion_utils.get_block_plain_text(block):
-            heading_index = i
-            break
-
-    if heading_index == -1:
-        print(f"Error: Could not find the '{heading_text}' heading.", file=sys.stderr)
-        return False
-
-    for i in range(heading_index + 1, len(all_blocks)):
-        block = all_blocks[i]
-        if block.get("type") in ["heading_1", "heading_2", "heading_3"]:
-            break
-
-        if block.get("type") == "column_list":
-            column_list_id = block["id"]
-            columns = notion_utils.get_all_blocks_recursively(notion, column_list_id)
-            if len(columns) < 2:
-                continue
-
-            for column in columns:
-                if column.get("type") == "column":
-                    if column.get("column", {}).get("width_ratio") == 0.125:
-                        image_column = column
-                    elif column.get("column", {}).get("width_ratio") == 0.875:
-                        text_column = column
-
-            image_column_blocks = notion_utils.get_all_blocks_recursively(
-                notion, image_column["id"]
-            )
-            text_column_blocks = notion_utils.get_all_blocks_recursively(
-                notion, text_column["id"]
-            )
-
-            column_image_url = None
-            for inner_block in image_column_blocks:
-                if inner_block.get("type") == "image" and inner_block.get(
-                    "image", {}
-                ).get("file"):
-                    column_image_url = (
-                        inner_block.get("image", {}).get("file", {}).get("url")
-                    )
-                    break
-
-            if (
-                not column_image_url
-                or column_image_url[:100] != education_image_url[:100]
-            ):
-                continue
-
-            for j, inner_block in enumerate(text_column_blocks):
-                if "Research Assistant" in notion_utils.get_block_plain_text(
-                    inner_block
-                ):
-                    title_annotations = get_block_annotations(inner_block)
-                    if j + 2 < len(text_column_blocks):
-                        date_block = text_column_blocks[j + 1]
-                        description_block = text_column_blocks[j + 2]
-
-                        date_text = "January - August 2023"
-                        description_text = "Assisted in conducting user experience research projects at my bachelor’s program, supporting data collection, analyzing user feedback, and preparing research reports. Developed strong skills in research methodologies and improved collaboration with interdisciplinary teams."
-
-                        date_annotations = get_block_annotations(date_block)
-                        description_annotations = get_block_annotations(
-                            description_block
-                        )
-
-                        if (
-                            date_text in notion_utils.get_block_plain_text(date_block)
-                            and description_text
-                            in notion_utils.get_block_plain_text(description_block)
-                            and title_annotations.get("bold")
-                            and date_annotations.get("italic")
-                            and date_annotations.get("color") == "gray"
-                            and description_annotations.get("color") == "default"
-                            and description_annotations.get("italic") != True
-                            and description_annotations.get("bold") != True
-                        ):
-                            print("Success: Verified new work history entry.")
-                            return True
-
-    print("Failure: Could not verify the new work history entry.", file=sys.stderr)
-    return False
+    print(
+        "Success: Verified Research Assistant entry (positioned first), summary "
+        "callout update, and Skills database entry."
+    )
+    return True
 
 
-def main():
-    """
-    Executes the verification process and exits with a status code.
-    """
+def main() -> None:
     notion = notion_utils.get_notion_client()
     main_id = sys.argv[1] if len(sys.argv) > 1 else None
     if verify(notion, main_id):
         sys.exit(0)
-    else:
-        sys.exit(1)
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tasks/notion/standard/self_assessment/hyperfocus_analysis_report/description.md
+++ b/tasks/notion/standard/self_assessment/hyperfocus_analysis_report/description.md
@@ -1,24 +1,27 @@
-Go to my Self Assessment page, and then create a hyperfocus analysis report by analyzing sessions with high productivity but significant challenges.
+Go to my Self Assessment page, and then add an inline hyperfocus analysis section by analyzing sessions with high productivity but significant challenges.
 
 **Task Requirements:**
-1. Create a new page titled "Hyperfocus Analysis Report" as a child of the Self Assessment page. The new page should be located between 'Why Use the Term "Hyperfocus"?' callout and the following divider line.
+1. In the Self Assessment page, directly between the 'Why Use the Term "Hyperfocus"?' callout and the divider line that follows it, insert a hyperfocus analysis section consisting of:
+   - A summary callout (described in step 4) at the top of the section
+   - Per-session content (described in step 3) following the summary callout
+   Do NOT create a separate child page; insert the blocks inline as direct children of the Self Assessment page.
 2. Query the "Hyperfocus Self-Assessment Worksheet" database to find all sessions where:
    - Work Completion Rate is greater than 80% (0.8)
    - At least one challenge is present in the Challenges field
-3. For each qualifying session, create a section with:
-   - A heading showing the date and activity type (format: YYYY-MM-DD Activity)
+3. For each qualifying session, append (after the summary callout) a section with:
+   - A level 2 heading showing the date and activity type (format: YYYY-MM-DD Activity)
    - A bullet list containing:
      - Focus factors used (e.g., Focus factors: XXX, YYY)
      - Energy level and mood (format: "Energy: X/10, Mood: Y/10")
      - Challenges faced (e.g., Challenges: XXX, YYY)
      - Strategies that helped overcome challenges (e.g., Strategies: XXX, YYY)
      - Work completion rate (format: "Completion: XX%")
-4. At the top of the page, add a callout block (type: "info") with:
+4. The summary callout (a callout block, type: "info") should contain:
    - Title: "Top 2 Most Effective Strategies"
-   - Content: List the 2 most frequently used strategies from all sessions, each on a new line with format "• Strategy Name (used in X sessions)"
+   - Content: List the 2 strategies that appear most frequently across the entire "Hyperfocus Self-Assessment Worksheet" database (count every entry in the database — do NOT limit counting to the filtered sessions from step 2), each on a new line with format "• Strategy Name (used in X sessions)"
 
 **Structure Requirements:**
-- The page must have the exact title "Hyperfocus Analysis Report"
+- All inserted blocks must be located strictly between the 'Why Use the Term "Hyperfocus"?' callout and the divider line that follows it
 - Each session section must start with a level 2 heading
 - All session details must be in bullet point format
-- The summary callout must be at the top of the page before any session details
+- The summary callout must come first in the inserted section, before any session heading

--- a/tasks/notion/standard/self_assessment/hyperfocus_analysis_report/verify.py
+++ b/tasks/notion/standard/self_assessment/hyperfocus_analysis_report/verify.py
@@ -12,11 +12,9 @@ def validate_comma_separated(text: str, expected_items: list) -> bool:
     if not text or not expected_items:
         return False
 
-    # Extract items from text
     items = [item.strip().lower() for item in text.split(",")]
     expected_lower = [item.lower() for item in expected_items]
 
-    # Check if all expected items are present
     for expected in expected_lower:
         if not any(expected in item or item in expected for item in items):
             return False
@@ -25,7 +23,9 @@ def validate_comma_separated(text: str, expected_items: list) -> bool:
 
 def verify(notion: Client, main_id: str = None) -> bool:
     """
-    Verifies that the Hyperfocus Analysis Report has been created correctly.
+    Verifies that the inline hyperfocus analysis section has been inserted
+    between the 'Why Use the Term "Hyperfocus"?' callout and the divider
+    line that follows it inside the Self Assessment page.
     """
     # Find the Self Assessment page
     self_assessment_page_id = main_id
@@ -37,73 +37,43 @@ def verify(notion: Client, main_id: str = None) -> bool:
             self_assessment_page_id = found_id
 
     if not self_assessment_page_id:
-        # Try to find by name
         self_assessment_page_id = notion_utils.find_page(notion, "Self Assessment")
 
     if not self_assessment_page_id:
         print("Error: Self Assessment page not found.", file=sys.stderr)
         return False
 
-    # Find the Hyperfocus Analysis Report page
-    report_page_id = None
-    report_position = -1
-    callout_position = -1
-    divider_position = -1
     children = notion.blocks.children.list(block_id=self_assessment_page_id).get(
         "results", []
     )
+
+    # Locate the 'Why Use the Term "Hyperfocus"?' callout and the first divider after it.
+    callout_idx = -1
+    divider_idx = -1
     for i, child in enumerate(children):
-        # Track position of callout with "Why Use the Term"
-        if child.get("type") == "callout":
-            callout_text = notion_utils.get_block_plain_text(child)
-            if "Why Use the Term" in callout_text and "Hyperfocus" in callout_text:
-                callout_position = i
+        if callout_idx == -1 and child.get("type") == "callout":
+            text = notion_utils.get_block_plain_text(child)
+            if "Why Use the Term" in text and "Hyperfocus" in text:
+                callout_idx = i
+        elif callout_idx != -1 and child.get("type") == "divider":
+            divider_idx = i
+            break
 
-        # Track position of divider
-        elif child.get("type") == "divider":
-            if callout_position != -1 and divider_position == -1:
-                divider_position = i
-
-        # Find the report page
-        elif child.get("type") == "child_page":
-            page_data = notion.pages.retrieve(page_id=child["id"])
-            title_prop = (
-                page_data.get("properties", {}).get("title", {}).get("title", [])
-            )
-            if (
-                title_prop
-                and title_prop[0].get("plain_text") == "Hyperfocus Analysis Report"
-            ):
-                report_page_id = child["id"]
-                report_position = i
-
-    if not report_page_id:
-        print("Error: 'Hyperfocus Analysis Report' page not found.", file=sys.stderr)
-        return False
-
-    # Verify position
-    if callout_position == -1:
+    if callout_idx == -1:
         print(
             "Error: Could not find 'Why Use the Term \"Hyperfocus\"?' callout.",
             file=sys.stderr,
         )
         return False
 
-    if divider_position == -1:
+    if divider_idx == -1:
         print("Error: Could not find divider after the callout.", file=sys.stderr)
         return False
 
-    if not (callout_position < report_position < divider_position):
-        print(
-            f"Error: Report page is not positioned between callout and divider. Positions: callout={callout_position}, report={report_position}, divider={divider_position}",
-            file=sys.stderr,
-        )
-        return False
+    # Section blocks: strictly between the callout and the divider.
+    section_blocks = children[callout_idx + 1 : divider_idx]
 
-    # Get all blocks from the report page
-    all_blocks = notion_utils.get_all_blocks_recursively(notion, report_page_id)
-
-    # Find the database in the Self Assessment page
+    # Find the worksheet database (recursively, since it lives inside a toggle).
     database_id = None
     for block in notion_utils.get_all_blocks_recursively(
         notion, self_assessment_page_id
@@ -124,7 +94,20 @@ def verify(notion: Client, main_id: str = None) -> bool:
         )
         return False
 
-    # Query database for sessions with >80% completion rate and challenges
+    # Top 2 strategies across ALL entries in the database (not filtered).
+    all_sessions = notion.databases.query(database_id=database_id).get("results", [])
+    all_strategies = []
+    for s in all_sessions:
+        strats = (
+            s.get("properties", {})
+            .get("Key Strategies Used", {})
+            .get("multi_select", [])
+        )
+        all_strategies.extend([x.get("name") for x in strats])
+    strategy_counts = Counter(all_strategies)
+    top_2_strategies = strategy_counts.most_common(2)
+
+    # Filtered sessions (>80% completion + at least one challenge).
     query_results = notion.databases.query(
         database_id=database_id,
         filter={
@@ -135,71 +118,40 @@ def verify(notion: Client, main_id: str = None) -> bool:
         },
     ).get("results", [])
 
-    if not query_results:
-        print(
-            "Warning: No sessions found with >80% completion rate and challenges.",
-            file=sys.stderr,
-        )
-        # Still check if the page structure is correct
-
-    # Verify page structure
-    has_callout = False
-    has_top_strategies = False
-    session_count = 0
-    found_sessions = {}  # Track sessions by date for validation
-
-    # Track strategies for validation - count from ALL sessions
-    all_sessions = notion.databases.query(database_id=database_id).get("results", [])
-    all_strategies = []
-    for session in all_sessions:
-        strategies = (
-            session.get("properties", {})
-            .get("Key Strategies Used", {})
-            .get("multi_select", [])
-        )
-        all_strategies.extend([s.get("name") for s in strategies])
-
-    strategy_counts = Counter(all_strategies)
-    top_2_strategies = strategy_counts.most_common(2)
-
-    # Build expected sessions from query results with all data
     expected_sessions = {}
-    for result in query_results:
-        date_prop = result.get("properties", {}).get("Date", {}).get("date", {})
+    for r in query_results:
+        date_prop = r.get("properties", {}).get("Date", {}).get("date", {})
         activity_prop = (
-            result.get("properties", {}).get("Activity", {}).get("select", {})
+            r.get("properties", {}).get("Activity", {}).get("select", {})
         )
         if date_prop and date_prop.get("start") and activity_prop:
             date_str = date_prop["start"]
             activity_name = activity_prop.get("name", "")
-
-            # Extract all session data for validation
             focus_factors = [
                 f.get("name", "")
-                for f in result.get("properties", {})
+                for f in r.get("properties", {})
                 .get("Focus Factors", {})
                 .get("multi_select", [])
             ]
             challenges = [
                 c.get("name", "")
-                for c in result.get("properties", {})
+                for c in r.get("properties", {})
                 .get("Challenges", {})
                 .get("multi_select", [])
             ]
             strategies = [
                 s.get("name", "")
-                for s in result.get("properties", {})
+                for s in r.get("properties", {})
                 .get("Key Strategies Used", {})
                 .get("multi_select", [])
             ]
-            energy = result.get("properties", {}).get("Energy Level", {}).get("number")
-            mood = result.get("properties", {}).get("Mood", {}).get("number")
+            energy = r.get("properties", {}).get("Energy Level", {}).get("number")
+            mood = r.get("properties", {}).get("Mood", {}).get("number")
             completion = (
-                result.get("properties", {})
+                r.get("properties", {})
                 .get("Work Completion Rate", {})
                 .get("number")
             )
-
             expected_sessions[date_str] = {
                 "activity": activity_name,
                 "focus_factors": focus_factors,
@@ -210,52 +162,53 @@ def verify(notion: Client, main_id: str = None) -> bool:
                 "completion": completion,
             }
 
+    # Walk section blocks.
+    has_callout = False
+    has_top_strategies = False
+    callout_seen_at = -1
+    found_sessions = {}
+    session_count = 0
     current_session_date = None
     current_session_data = None
-    session_bullet_points = {}  # Track bullet points for each session
+    session_bullet_points = {}
 
-    for i, block in enumerate(all_blocks):
+    for i, block in enumerate(section_blocks):
         block_type = block.get("type")
 
-        # Check for callout at the top
-        if block_type == "callout" and i < 5:  # Should be near the top
-            callout_text = notion_utils.get_block_plain_text(block)
-            if "Top 2 Most Effective Strategies" in callout_text:
+        if block_type == "callout":
+            text = notion_utils.get_block_plain_text(block)
+            if "Top 2 Most Effective Strategies" in text:
                 has_callout = True
-                # Check if it contains strategy information
-                s1, n1 = top_2_strategies[0]
-                s2, n2 = top_2_strategies[1]
-                t1 = f"{s1} (used in {n1} sessions)"
-                t2 = f"{s2} (used in {n2} sessions)"
+                if callout_seen_at == -1:
+                    callout_seen_at = i
+                if len(top_2_strategies) >= 2:
+                    s1, n1 = top_2_strategies[0]
+                    s2, n2 = top_2_strategies[1]
+                    t1 = f"{s1} (used in {n1} sessions)"
+                    t2 = f"{s2} (used in {n2} sessions)"
+                    if t1 in text and t2 in text:
+                        has_top_strategies = True
 
-                if t1 in callout_text and t2 in callout_text:
-                    has_top_strategies = True
-                    break
-
-        # Check for session headings with format YYYY-MM-DD Activity
         if block_type == "heading_2":
             heading_text = notion_utils.get_block_plain_text(block)
-            # Check if heading matches expected format
-            for date_str, session_data in expected_sessions.items():
-                activity = session_data["activity"]
-                expected_heading = f"{date_str} {activity}"
+            # A new heading_2 closes the previous session's bullet scope.
+            current_session_date = None
+            current_session_data = None
+            for date_str, sd in expected_sessions.items():
+                expected_heading = f"{date_str} {sd['activity']}"
                 if expected_heading in heading_text:
-                    found_sessions[date_str] = session_data
+                    found_sessions[date_str] = sd
                     session_count += 1
                     current_session_date = date_str
-                    current_session_data = session_data
+                    current_session_data = sd
                     session_bullet_points[date_str] = []
                     break
 
-        # Check for bullet points with session details
         if block_type == "bulleted_list_item" and current_session_data:
             bullet_text = notion_utils.get_block_plain_text(block)
-
-            # Track bullet points for current session
             if current_session_date:
                 session_bullet_points[current_session_date].append(bullet_text)
 
-            # Validate specific bullet point content
             if bullet_text.startswith("Focus factors"):
                 content = bullet_text.split(":", 1)[1].strip()
                 expected_factors = current_session_data.get("focus_factors", [])
@@ -267,16 +220,13 @@ def verify(notion: Client, main_id: str = None) -> bool:
                     return False
 
             elif "Energy" in bullet_text and "Mood" in bullet_text:
-                # Extract energy and mood values
-                energy_match = re.search(r"Energy:\s*(\d+)/10", bullet_text)
-                mood_match = re.search(r"Mood:\s*(\d+)/10", bullet_text)
-
-                if energy_match and mood_match:
-                    found_energy = int(energy_match.group(1))
-                    found_mood = int(mood_match.group(1))
+                em = re.search(r"Energy:\s*(\d+)/10", bullet_text)
+                mm = re.search(r"Mood:\s*(\d+)/10", bullet_text)
+                if em and mm:
+                    found_energy = int(em.group(1))
+                    found_mood = int(mm.group(1))
                     expected_energy = current_session_data.get("energy")
                     expected_mood = current_session_data.get("mood")
-
                     if found_energy != expected_energy or found_mood != expected_mood:
                         print(
                             f"Error: Energy/Mood mismatch for {current_session_date}. Expected: Energy: {expected_energy}/10, Mood: {expected_mood}/10",
@@ -313,15 +263,12 @@ def verify(notion: Client, main_id: str = None) -> bool:
                     return False
 
             elif bullet_text.startswith("Completion"):
-                # Extract completion percentage
-                completion_match = re.search(r"Completion:\s*(\d+)%", bullet_text)
-
-                if completion_match:
-                    found_completion = int(completion_match.group(1))
+                cm = re.search(r"Completion:\s*(\d+)%", bullet_text)
+                if cm:
+                    found_completion = int(cm.group(1))
                     expected_completion = int(
                         current_session_data.get("completion", 0) * 100
                     )
-
                     if found_completion != expected_completion:
                         print(
                             f"Error: Completion rate mismatch for {current_session_date}. Expected: {expected_completion}%, Found: {found_completion}%",
@@ -335,10 +282,10 @@ def verify(notion: Client, main_id: str = None) -> bool:
                     )
                     return False
 
-    # Verify all sessions have complete bullet points
+    # Per-session bullet completeness.
     for date_str, bullets in session_bullet_points.items():
-        bullets_text = " ".join(bullets)
-        required_items = [
+        bt = " ".join(bullets)
+        required = [
             "Focus factors",
             "Energy:",
             "Mood:",
@@ -346,44 +293,51 @@ def verify(notion: Client, main_id: str = None) -> bool:
             "Strategies",
             "Completion",
         ]
-        missing_items = []
-
-        for item in required_items:
-            if item not in bullets_text:
-                missing_items.append(item)
-
-        if missing_items:
+        missing = [r for r in required if r not in bt]
+        if missing:
             print(
-                f"Error: Missing bullet points for session {date_str}: {', '.join(missing_items)}",
+                f"Error: Missing bullet points for session {date_str}: {', '.join(missing)}",
                 file=sys.stderr,
             )
             return False
 
-    # Verify all requirements
+    # Final structural checks.
     if not has_callout:
         print(
-            "Error: Missing callout block with 'Top 2 Most Effective Strategies'.",
+            "Error: Missing callout block with 'Top 2 Most Effective Strategies' between the 'Why Use the Term \"Hyperfocus\"?' callout and the following divider.",
             file=sys.stderr,
         )
         return False
 
     if not has_top_strategies and len(top_2_strategies) > 0:
-        print("Error: Callout doesn't contain strategy information.", file=sys.stderr)
+        print(
+            "Error: Callout doesn't contain correct top 2 strategy information.",
+            file=sys.stderr,
+        )
+        return False
+
+    # The summary callout must come before any session heading_2.
+    first_h2_idx = next(
+        (i for i, b in enumerate(section_blocks) if b.get("type") == "heading_2"),
+        len(section_blocks),
+    )
+    if callout_seen_at == -1 or callout_seen_at > first_h2_idx:
+        print(
+            "Error: 'Top 2 Most Effective Strategies' callout must come before any session heading.",
+            file=sys.stderr,
+        )
         return False
 
     if query_results and session_count == 0:
-        print("Error: No session sections found with proper headings.", file=sys.stderr)
+        print(
+            "Error: No session sections found with proper headings.", file=sys.stderr
+        )
         return False
 
-    # Check if all expected sessions are present
-    missing_sessions = []
-    for date_str in expected_sessions.keys():
-        if date_str not in found_sessions:
-            missing_sessions.append(date_str)
-
-    if missing_sessions:
+    missing = [d for d in expected_sessions if d not in found_sessions]
+    if missing:
         print(
-            f"Error: Missing session sections for dates: {', '.join(missing_sessions)}",
+            f"Error: Missing session sections for dates: {', '.join(missing)}",
             file=sys.stderr,
         )
         return False
@@ -395,7 +349,7 @@ def verify(notion: Client, main_id: str = None) -> bool:
         )
 
     print(
-        "Success: Hyperfocus Analysis Report created with proper structure and content."
+        "Success: Hyperfocus analysis section created with proper structure and content."
     )
     return True
 

--- a/tasks/notion/standard/standard_operating_procedure/section_organization/description.md
+++ b/tasks/notion/standard/standard_operating_procedure/section_organization/description.md
@@ -16,4 +16,4 @@ Modify the structure of the Standard Operating Procedure page in Notion by reorg
 - Position the "Tools" section in the left column
 - Position the "Terminologies" section in the right column
 - In the "Tools" column, add links to the Notion and Figma pages using appropriate reference blocks
-- Preserve the original child pages from the "Tools" section in a toggle block placed below the column layout, with the toggle titled "original pages"
+- Preserve access to the original Notion and Figma child pages from the "Tools" section inside a toggle titled "original pages", positioned below the column layout (the original pages must remain reachable from this toggle)

--- a/tasks/notion/standard/standard_operating_procedure/section_organization/verify.py
+++ b/tasks/notion/standard/standard_operating_procedure/section_organization/verify.py
@@ -187,26 +187,52 @@ def verify(notion: Client, main_id: str = None) -> bool:
         print(f"Error getting toggle children: {e}", file=sys.stderr)
         return False
     
-    # Check for child_page blocks (Notion and Figma)
+    # Accept either nested child_page blocks (UI-built path) or
+    # link_to_page references (API-built path). Notion's public API does not
+    # expose a way to move/create a child_page block inside a toggle, so an
+    # API agent can only reference the original pages via link_to_page.
+    def _resolve_page_title(target_id: str) -> str:
+        try:
+            page = notion.pages.retrieve(page_id=target_id)
+        except Exception:
+            return ""
+        title_prop = page.get("properties", {}).get("title", {})
+        rich_text = title_prop.get("title", [])
+        return "".join(rt.get("plain_text", "") for rt in rich_text)
+
     notion_page_found = False
     figma_page_found = False
-    
+
     for block in toggle_children:
-        if block.get("type") == "child_page":
+        btype = block.get("type")
+        if btype == "child_page":
             title = block.get("child_page", {}).get("title", "")
-            if title == "Notion":
-                notion_page_found = True
-                print("✓ Found 'Notion' child page in toggle")
-            elif title == "Figma":
-                figma_page_found = True
-                print("✓ Found 'Figma' child page in toggle")
-    
+        elif btype == "link_to_page":
+            target_id = block.get("link_to_page", {}).get("page_id")
+            title = _resolve_page_title(target_id) if target_id else ""
+        else:
+            continue
+        if title == "Notion":
+            notion_page_found = True
+            print(f"✓ Found 'Notion' page reference in toggle (via {btype})")
+        elif title == "Figma":
+            figma_page_found = True
+            print(f"✓ Found 'Figma' page reference in toggle (via {btype})")
+
     if not notion_page_found:
-        print("Error: 'Notion' child page not found in toggle block.", file=sys.stderr)
+        print(
+            "Error: No 'Notion' page reference found in toggle block "
+            "(expected child_page or link_to_page targeting the original 'Notion' page).",
+            file=sys.stderr,
+        )
         return False
-    
+
     if not figma_page_found:
-        print("Error: 'Figma' child page not found in toggle block.", file=sys.stderr)
+        print(
+            "Error: No 'Figma' page reference found in toggle block "
+            "(expected child_page or link_to_page targeting the original 'Figma' page).",
+            file=sys.stderr,
+        )
         return False
     
     # Step 6: Verify that original sections no longer exist at top level


### PR DESCRIPTION
Stabilizes 11 standard Notion tasks (verifiers + descriptions) so they are reachable under the current MCP toolset and verify deterministically. Opened against `pin-all-versions`, matching the pg (#257) and playwright_webarena (#254) verify PRs.

Scope: only `tasks/notion/standard/**` — no src, Docker, deps, or other-service changes.

Tasks touched:
- quarterly_review_dashboard — repair verifier, tighten description
- study_session_tracker — pin date in description, tighten verifier
- verification_expired_update — stable identification for expired pages
- daily_itinerary_overview — tighten verifier (description unchanged)
- work_history_addition — redesign to be reachable under current MCP toolset
- hyperfocus_analysis_report — make position constraint reachable, disambiguate strategy scope
- section_organization — accept link_to_page in toggle for API agents
- employee_onboarding — reorder so DB is created inside Hub
- online_resume/layout_adjustment — relax Skills format checks not stated in description
- packing_progress_summary — make Step 1 imperative, disambiguate "check"
- restaurant_expenses_sync — normalize curly apostrophe, narrow nbsp in verify
