### PR TITLE
feat: allow 'max' reasoning effort

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -113,7 +113,7 @@ def main():
     parser.add_argument(
         "--reasoning-effort",
         default="default",
-        choices=["default", "minimal", "low", "medium", "high", "xhigh"],
+        choices=["default", "minimal", "low", "medium", "high", "xhigh", "max"],
         help="Reasoning effort level for supported models (default: None)",
     )
 


### PR DESCRIPTION
## What

- Register `openai/gpt-5.5` (public OpenAI endpoint) in `ModelConfig`.
- Allow `xhigh` and `max` as `--reasoning-effort` choices.

## Why

We need to benchmark gpt-5.5 at `xhigh` and Claude Opus 4.x at `max` reasoning effort. The CLI previously capped the choices at `high`.

## Notes

`reasoning_effort` is already passed straight through to LiteLLM (`completion_kwargs["reasoning_effort"]`), so no agent-side changes are required — this PR only widens the CLI allow-list and adds the public model entry. gpt-5's Responses API is handled internally by LiteLLM; no explicit Responses-API code is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)