### PR TITLE
fix: case-insensitive match for missing-semester find_legacy_name

### DIFF
--- a/tasks/github/standard/missing-semester/find_legacy_name/verify.py
+++ b/tasks/github/standard/missing-semester/find_legacy_name/verify.py
@@ -95,8 +95,11 @@ def verify() -> bool:
     # 2. Check that the content matches expected answer
     print("2. Verifying ANSWER.md content...")
     answer_content = answer_content.strip()
-    
-    if answer_content not in EXPECTED_CONTENTS:
+
+    # Match case-insensitively: the title and domain are accepted regardless of
+    # capitalization (e.g. "hacker tools" / "Hacker-Tools.github.io" both pass).
+    expected_lower = {c.lower() for c in EXPECTED_CONTENTS}
+    if answer_content.lower() not in expected_lower:
         print(f"Error: ANSWER.md content does not match expected answer(s)", file=sys.stderr)
         print(f"Expected one of: {sorted(EXPECTED_CONTENTS)}", file=sys.stderr)
         print(f"Found: {answer_content}", file=sys.stderr)


### PR DESCRIPTION
## What

The `missing-semester/find_legacy_name` verifier compared the `ANSWER.md` content against the expected `[Hacker Tools](https://hacker-tools.github.io)` string with an exact, case-sensitive match.

## Change

Compare both sides lowercased, so the legacy name and domain are accepted regardless of capitalization (e.g. `hacker tools` / `Hacker-Tools.github.io` now pass). The required format (brackets, parens, URL structure) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)